### PR TITLE
Give up connection attempt to safekeeper after timeout.

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2309,6 +2309,17 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
+		{"wal_acceptor_connect_timeout", PGC_SIGHUP, REPLICATION_STANDBY,
+			gettext_noop("Timeout after which give up connection attempt to safekeeper."),
+			NULL,
+			GUC_UNIT_MS
+		},
+		&wal_acceptor_connect_timeout,
+		5000, 0, INT_MAX,
+		NULL, NULL, NULL
+	},
+
+	{
 		{"max_connections", PGC_POSTMASTER, CONN_AUTH_SETTINGS,
 			gettext_noop("Sets the maximum number of concurrent connections."),
 			NULL

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -27,6 +27,7 @@
 
 extern char* wal_acceptors_list;
 extern int   wal_acceptor_reconnect_timeout;
+extern int   wal_acceptor_connect_timeout;
 extern bool  am_wal_proposer;
 
 struct WalProposerConn; /* Defined in libpqwalproposer */
@@ -346,6 +347,7 @@ typedef struct Safekeeper
 
 	int                 eventPos;       /* position in wait event set. Equal to -1 if no event */
 	SafekeeperState     state;          /* safekeeper state machine state */
+	TimestampTz         startedConnAt;  /* when connection attempt started */
 	AcceptorGreeting    greetResponse;  /* acceptor greeting */
 	VoteResponse        voteResponse;   /* the vote */
 	AppendResponse      appendResponse; /* feedback for master */


### PR DESCRIPTION
Enforces reconnection soon when packets are dropped, e.g. after turning ec2
instance off.

ref https://github.com/neondatabase/neon/issues/1491