### PR TITLE
Avoid "bad syscall 39" on assertion failure in WAL redo process.

### DIFF
--- a/src/backend/tcop/zenith_wal_redo.c
+++ b/src/backend/tcop/zenith_wal_redo.c
@@ -125,6 +125,13 @@ enter_seccomp_mode(void)
 		PG_SCMP_ALLOW(mmap),
 		PG_SCMP_ALLOW(munmap),
 #endif
+		/*
+		 * getpid() is called on assertion failure, in ExceptionalCondition.
+		 * It's not really needed, but seems pointless to hide it either. The
+		 * system call unlikely to expose a kernel vulnerability, and the PID
+		 * is stored in MyProcPid anyway.
+		 */
+		PG_SCMP_ALLOW(getpid),
 
 		/* Enable those for a proper shutdown.
 		PG_SCMP_ALLOW(munmap),


### PR DESCRIPTION
ExceptionalCondition calls getpid(), which is currently forbidden by
seccomp. You only get there if something else went wrong, but the "bad
syscall" error hides the underlying cause of the error, which makes
debugging hard.