### PR TITLE
Verify basebackup LSN against consensus LSN in walproposer.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -750,6 +750,9 @@ typedef struct XLogCtlData
 	XLogRecPtr	lastFpwDisableRecPtr;
 	XLogRecPtr  lastWrittenPageLSN;
 
+	/* neon: copy of startup's RedoStartLSN for walproposer's use */
+	XLogRecPtr	RedoStartLSN;
+
 	/*
 	 * size of a timeline in zenith pageserver.
 	 * used to enforce timeline size limit.
@@ -6896,6 +6899,8 @@ StartupXLOG(void)
 
 		checkPointLoc = zenithLastRec;
 		RedoStartLSN = ControlFile->checkPointCopy.redo;
+		/* make basebackup LSN available for walproposer */
+		XLogCtl->RedoStartLSN = RedoStartLSN;
 		EndRecPtr = ControlFile->checkPointCopy.redo;
 
 		memcpy(&checkPoint, &ControlFile->checkPointCopy, sizeof(CheckPoint));
@@ -6966,6 +6971,7 @@ StartupXLOG(void)
 		/* Get the last valid checkpoint record. */
 		checkPointLoc = ControlFile->checkPoint;
 		RedoStartLSN = ControlFile->checkPointCopy.redo;
+		XLogCtl->RedoStartLSN = RedoStartLSN;
 		record = ReadCheckpointRecord(xlogreader, checkPointLoc, 1, true);
 		if (record != NULL)
 		{
@@ -8828,6 +8834,16 @@ SetLastWrittenPageLSN(XLogRecPtr lsn)
 	if (lsn > XLogCtl->lastWrittenPageLSN)
 		XLogCtl->lastWrittenPageLSN = lsn;
 	SpinLockRelease(&XLogCtl->info_lck);
+}
+
+/*
+ * RedoStartLsn is set only once by startup process, locking is not required
+ * after its exit.
+ */
+XLogRecPtr
+GetRedoStartLsn(void)
+{
+	return XLogCtl->RedoStartLSN;
 }
 
 

--- a/src/backend/storage/ipc/ipci.c
+++ b/src/backend/storage/ipc/ipci.c
@@ -152,7 +152,7 @@ CreateSharedMemoryAndSemaphores(void)
 		size = add_size(size, SyncScanShmemSize());
 		size = add_size(size, AsyncShmemSize());
 
-		size = add_size(size, ZenithFeedbackShmemSize());
+		size = add_size(size, WalproposerShmemSize());
 
 #ifdef EXEC_BACKEND
 		size = add_size(size, ShmemBackendArraySize());
@@ -274,7 +274,7 @@ CreateSharedMemoryAndSemaphores(void)
 	SyncScanShmemInit();
 	AsyncShmemInit();
 
-	ZenithFeedbackShmemInit();
+	WalproposerShmemInit();
 
 #ifdef EXEC_BACKEND
 

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -354,6 +354,8 @@ extern void RemovePromoteSignalFiles(void);
 extern void SetLastWrittenPageLSN(XLogRecPtr lsn);
 extern XLogRecPtr GetLastWrittenPageLSN(void);
 
+extern XLogRecPtr GetRedoStartLsn(void);
+
 extern void SetZenithCurrentClusterSize(uint64 size);
 extern uint64 GetZenithCurrentClusterSize(void);
 

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -283,12 +283,12 @@ typedef	struct ZenithFeedback
 } ZenithFeedback;
 
 
-typedef struct ZenithFeedbackState
+typedef struct WalproposerShmemState
 {
 	slock_t		mutex;
 	ZenithFeedback feedback;
-
-} ZenithFeedbackState;
+	term_t		mineLastElectedTerm;
+} WalproposerShmemState;
 
 /*
  * Report safekeeper state to proposer
@@ -393,8 +393,8 @@ void ParseZenithFeedbackMessage(StringInfo reply_message,
 void       StartReplication(StartReplicationCmd *cmd);
 void       WalProposerSync(int argc, char *argv[]);
 
-Size ZenithFeedbackShmemSize(void);
-bool ZenithFeedbackShmemInit(void);
+Size WalproposerShmemSize(void);
+bool WalproposerShmemInit(void);
 void zenith_feedback_set(ZenithFeedback *zf);
 void zenith_feedback_get_lsns(XLogRecPtr *writeLsn, XLogRecPtr *flushLsn, XLogRecPtr *applyLsn);
 

--- a/src/include/replication/walproposer.h
+++ b/src/include/replication/walproposer.h
@@ -11,7 +11,7 @@
 #include "replication/walreceiver.h"
 
 #define SK_MAGIC              0xCafeCeefu
-#define SK_PROTOCOL_VERSION   1
+#define SK_PROTOCOL_VERSION   2
 
 #define MAX_SAFEKEEPERS        32
 #define MAX_SEND_SIZE         (XLOG_BLCKSZ * 16) /* max size of a single WAL message */
@@ -147,6 +147,9 @@ typedef enum
 /* Consensus logical timestamp. */
 typedef uint64 term_t;
 
+/* neon storage node id */
+typedef uint64 NNodeId;
+
 /*
  * Proposer <-> Acceptor messaging.
  */
@@ -177,6 +180,7 @@ typedef struct AcceptorGreeting
 {
 	AcceptorProposerMessage apm;
 	term_t		term;
+	NNodeId		nodeId;
 } AcceptorGreeting;
 
 /*
@@ -214,6 +218,7 @@ typedef struct VoteResponse {
 	XLogRecPtr flushLsn;
 	XLogRecPtr truncateLsn;  /* minimal LSN which may be needed for recovery of some safekeeper */
 	TermHistory termHistory;
+	XLogRecPtr timelineStartLsn; /* timeline globally starts at this LSN */
 } VoteResponse;
 
 /*
@@ -228,6 +233,8 @@ typedef struct ProposerElected
 	XLogRecPtr startStreamingAt;
 	/* history of term switches up to this proposer */
 	TermHistory *termHistory;
+	/* timeline globally starts at this LSN */
+	XLogRecPtr timelineStartLsn;
 } ProposerElected;
 
 /*


### PR DESCRIPTION
```
    Verify basebackup LSN against consensus LSN in walproposer.
    
    If not, such basebackup (clog etc) is inconsistent and must be retaken.
    
    Basebackup LSN is taken by exposing xlog.c RedoStartLSN in shmem.
    
    ref https://github.com/neondatabase/neon/issues/594

```

Based on https://github.com/neondatabase/postgres/pull/155