### PR TITLE
zenith_test_utils extension: add neon_xlogflush()

### DIFF
--- a/contrib/zenith_test_utils/zenith_test_utils--1.0.sql
+++ b/contrib/zenith_test_utils/zenith_test_utils--1.0.sql
@@ -22,3 +22,8 @@ CREATE FUNCTION get_raw_page_at_lsn(tbspc oid, db oid, relfilenode oid, forknum 
 RETURNS bytea
 AS 'MODULE_PATHNAME', 'get_raw_page_at_lsn_ex'
 LANGUAGE C PARALLEL UNSAFE;
+
+CREATE FUNCTION neon_xlogflush(lsn pg_lsn)
+RETURNS VOID
+AS 'MODULE_PATHNAME', 'neon_xlogflush'
+LANGUAGE C PARALLEL UNSAFE;

--- a/contrib/zenith_test_utils/zenithtest.c
+++ b/contrib/zenith_test_utils/zenithtest.c
@@ -20,6 +20,7 @@
 #include "storage/buf_internals.h"
 #include "storage/bufmgr.h"
 #include "utils/builtins.h"
+#include "utils/pg_lsn.h"
 #include "utils/rel.h"
 #include "utils/varlena.h"
 #include "zenith/pagestore_client.h"
@@ -32,6 +33,7 @@ PG_FUNCTION_INFO_V1(test_consume_xids);
 PG_FUNCTION_INFO_V1(clear_buffer_cache);
 PG_FUNCTION_INFO_V1(get_raw_page_at_lsn);
 PG_FUNCTION_INFO_V1(get_raw_page_at_lsn_ex);
+PG_FUNCTION_INFO_V1(neon_xlogflush);
 
 /*
  * Linkage to functions in zenith module.
@@ -288,4 +290,15 @@ get_raw_page_at_lsn_ex(PG_FUNCTION_ARGS)
 		zenith_read_at_lsn(rnode, forknum, blkno, read_lsn, request_latest, raw_page_data);
 		PG_RETURN_BYTEA_P(raw_page);
 	}
+}
+
+/*
+ * Directly calls XLogFlush(lsn) to flush WAL buffers.
+ */
+Datum
+neon_xlogflush(PG_FUNCTION_ARGS)
+{
+	XLogRecPtr lsn = PG_GETARG_LSN(0);
+	XLogFlush(lsn);
+	PG_RETURN_VOID();
 }


### PR DESCRIPTION
This function is to simplify complex WAL generation in https://github.com/neondatabase/neon/pull/1574

`pg_logical_emit_message` is the easiest way to get a big WAL record, but:
* If it's transactional, it gets `COMMIT` record right after
* If it's not, WAL is not flushed at all. The function helps here, so we
  don't rely on the background WAL writer.

I suspect the plain `xlogflush()` name may collide in the future, hence the prefix.