### PR TITLE
Revert "Update last written LSN for gin/gist index metadata (#182)"

### DIFF
--- a/src/backend/access/gin/gininsert.c
+++ b/src/backend/access/gin/gininsert.c
@@ -421,9 +421,8 @@ ginbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rnode.node.relNode, 0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node.relNode);
 	}
+	SetLastWrittenPageLSN(XactLastRecEnd);
 
 	smgr_end_unlogged_build(index->rd_smgr);
 

--- a/src/backend/access/gist/gistbuild.c
+++ b/src/backend/access/gist/gistbuild.c
@@ -335,11 +335,9 @@ gistbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 			log_newpage_range(index, MAIN_FORKNUM,
 							  0, RelationGetNumberOfBlocks(index),
 							  true);
-			SetLastWrittenLSNForBlockRange(XactLastRecEnd,
-							  index->rd_smgr->smgr_rnode.node.relNode,
-							  0, RelationGetNumberOfBlocks(index));
-			SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node.relNode);
 		}
+		SetLastWrittenPageLSN(XactLastRecEnd);
+
 		smgr_end_unlogged_build(index->rd_smgr);
 	}
 
@@ -471,9 +469,7 @@ gist_indexsortbuild(GISTBuildState *state)
 
 		lsn = log_newpage(&state->indexrel->rd_node, MAIN_FORKNUM, GIST_ROOT_BLKNO,
 					pagestate->page, true);
-		SetLastWrittenLSNForBlock(lsn, state->indexrel->rd_smgr->smgr_rnode.node.relNode,
-								  GIST_ROOT_BLKNO);
-		SetLastWrittenLSNForRelation(lsn, state->indexrel->rd_smgr->smgr_rnode.node.relNode);
+		SetLastWrittenPageLSN(lsn);
 	}
 
 	pfree(pagestate->page);

--- a/src/backend/access/spgist/spginsert.c
+++ b/src/backend/access/spgist/spginsert.c
@@ -143,10 +143,8 @@ spgbuild(Relation heap, Relation index, IndexInfo *indexInfo)
 		log_newpage_range(index, MAIN_FORKNUM,
 						  0, RelationGetNumberOfBlocks(index),
 						  true);
-		SetLastWrittenLSNForBlockRange(XactLastRecEnd, index->rd_smgr->smgr_rnode.node.relNode,
-						  0, RelationGetNumberOfBlocks(index));
-		SetLastWrittenLSNForRelation(XactLastRecEnd, index->rd_smgr->smgr_rnode.node.relNode);
 	}
+	SetLastWrittenPageLSN(XactLastRecEnd);
 
 	smgr_end_unlogged_build(index->rd_smgr);
 

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -112,7 +112,6 @@ int			wal_retrieve_retry_interval = 5000;
 int			max_slot_wal_keep_size_mb = -1;
 bool		track_wal_io_timing = false;
 uint64      predefined_sysidentifier;
-int			lastWrittenLsnCacheSize;
 
 #ifdef WAL_DEBUG
 bool		XLOG_DEBUG = false;
@@ -181,28 +180,6 @@ const struct config_enum_entry recovery_target_action_options[] = {
 	{"shutdown", RECOVERY_TARGET_ACTION_SHUTDOWN, false},
 	{NULL, 0, false}
 };
-
-
-/*
- * We are not taken in account dbnode, spcnode, forknum fields of
- * relation tag, because possibility of collision is assumed to be small
- * and should not affect performance. And reducing cache key size speed-up
- * hash calculation and comparison.
- */
-typedef struct LastWrittenLsnCacheKey
-{
-	Oid         relid;
-	BlockNumber bucket;
-} LastWrittenLsnCacheKey;
-
-typedef struct LastWrittenLsnCacheEntry
-{
-	LastWrittenLsnCacheKey key;
-	XLogRecPtr             lsn;
-	/* L2-List for LRU replacement algorithm */
-	struct LastWrittenLsnCacheEntry* next;
-	struct LastWrittenLsnCacheEntry* prev;
-} LastWrittenLsnCacheEntry;
 
 /*
  * Statistics for current checkpoint are collected in this global struct.
@@ -773,17 +750,6 @@ typedef struct XLogCtlData
 	XLogRecPtr	lastFpwDisableRecPtr;
 	XLogRecPtr  lastWrittenPageLSN;
 
-	/*
-	 * Maximal last written LSN for pages not present in lastWrittenLsnCache
-	 */
-	XLogRecPtr  maxLastWrittenLsn;
-
-	/*
-	 * Double linked list to implement LRU replacement policy for last written LSN cache.
-	 * Access to this list as well as to last written LSN cache is protected by 'LastWrittenLsnLock'.
-	 */
-	LastWrittenLsnCacheEntry lastWrittenLsnLRU;
-
 	/* neon: copy of startup's RedoStartLSN for walproposer's use */
 	XLogRecPtr	RedoStartLSN;
 
@@ -795,7 +761,6 @@ typedef struct XLogCtlData
 	slock_t		info_lck;		/* locks shared variables shown above */
 } XLogCtlData;
 
-
 static XLogCtlData *XLogCtl = NULL;
 
 /* a private copy of XLogCtl->Insert.WALInsertLocks, for convenience */
@@ -805,19 +770,6 @@ static WALInsertLockPadded *WALInsertLocks = NULL;
  * We maintain an image of pg_control in shared memory.
  */
 static ControlFileData *ControlFile = NULL;
-
-#define LAST_WRITTEN_LSN_CACHE_BUCKET 1024 /* blocks = 8Mb */
-
-
-/*
- * Cache of last written LSN for each relation chunk (hash bucket).
- * Also to provide request LSN for smgrnblocks, smgrexists there is pseudokey=InvalidBlockId which stores LSN of last
- * relation metadata update.
- * Size of the cache is limited by GUC variable lastWrittenLsnCacheSize ("lsn_cache_size"),
- * pages are replaced using LRU algorithm, based on L2-list.
- * Access to this cache is protected by 'LastWrittenLsnLock'.
- */
-static HTAB *lastWrittenLsnCache;
 
 /*
  * Calculate the amount of space left on the page after 'endptr'. Beware
@@ -5179,8 +5131,11 @@ LocalProcessControlFile(bool reset)
 	ReadControlFile();
 }
 
-static Size
-XLOGCtlShmemSize(void)
+/*
+ * Initialization of shared memory for XLOG
+ */
+Size
+XLOGShmemSize(void)
 {
 	Size		size;
 
@@ -5220,16 +5175,6 @@ XLOGCtlShmemSize(void)
 	return size;
 }
 
-/*
- * Initialization of shared memory for XLOG
- */
-Size
-XLOGShmemSize(void)
-{
-	return XLOGCtlShmemSize() +
-		hash_estimate_size(lastWrittenLsnCacheSize, sizeof(LastWrittenLsnCacheEntry));
-}
-
 void
 XLOGShmemInit(void)
 {
@@ -5259,15 +5204,6 @@ XLOGShmemInit(void)
 	XLogCtl = (XLogCtlData *)
 		ShmemInitStruct("XLOG Ctl", XLOGShmemSize(), &foundXLog);
 
-	{
-		static HASHCTL info;
-		info.keysize = sizeof(LastWrittenLsnCacheKey);
-		info.entrysize = sizeof(LastWrittenLsnCacheEntry);
-		lastWrittenLsnCache = ShmemInitHash("last_written_lsn_cache",
-											lastWrittenLsnCacheSize, lastWrittenLsnCacheSize,
-											&info,
-											HASH_ELEM | HASH_BLOBS);
-	}
 	localControlFile = ControlFile;
 	ControlFile = (ControlFileData *)
 		ShmemInitStruct("Control File", sizeof(ControlFileData), &foundCFile);
@@ -8152,8 +8088,7 @@ StartupXLOG(void)
 
 	XLogCtl->LogwrtRqst.Write = EndOfLog;
 	XLogCtl->LogwrtRqst.Flush = EndOfLog;
-	XLogCtl->maxLastWrittenLsn = EndOfLog;
-	XLogCtl->lastWrittenLsnLRU.next = XLogCtl->lastWrittenLsnLRU.prev = &XLogCtl->lastWrittenLsnLRU;
+	XLogCtl->lastWrittenPageLSN = EndOfLog;
 
 	LocalSetXLogInsertAllowed();
 
@@ -8876,144 +8811,29 @@ GetInsertRecPtr(void)
 }
 
 /*
- * GetLastWrittenLSN -- Returns maximal LSN of written page.
- * It returns an upper bound for the last written LSN of a given page,
- * either from a cached last written LSN or a global maximum last written LSN.
- * If rnode is InvalidOid then we calculate maximum among all cached LSN and maxLastWrittenLsn.
- * If cache is large enough ,iterting through all hash items may be rather expensive.
- * But GetLastWrittenLSN(InvalidOid) is used only by zenith_dbsize which is not performance critical.
+ * GetLastWrittenPageLSN -- Returns maximal LSN of written page
  */
 XLogRecPtr
-GetLastWrittenLSN(Oid rnode, BlockNumber blkno)
+GetLastWrittenPageLSN(void)
 {
 	XLogRecPtr lsn;
-	LastWrittenLsnCacheEntry* entry;
-
-	LWLockAcquire(LastWrittenLsnLock, LW_SHARED);
-
-	/* Maximal last written LSN among all non-cached pages */
-	lsn = XLogCtl->maxLastWrittenLsn;
-
-	if (rnode != InvalidOid)
-	{
-		LastWrittenLsnCacheKey key;
-		key.relid = rnode;
-		key.bucket = blkno / LAST_WRITTEN_LSN_CACHE_BUCKET;
-		entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
-		if (entry != NULL)
-			lsn = entry->lsn;
-	}
-	else
-	{
-		HASH_SEQ_STATUS seq;
-		/* Find maximum of all cached LSNs */
-		hash_seq_init(&seq, lastWrittenLsnCache);
-		while ((entry = (LastWrittenLsnCacheEntry *) hash_seq_search(&seq)) != NULL)
-		{
-			if (entry->lsn > lsn)
-				lsn = entry->lsn;
-		}
-	}
-	LWLockRelease(LastWrittenLsnLock);
+	SpinLockAcquire(&XLogCtl->info_lck);
+	lsn = XLogCtl->lastWrittenPageLSN;
+	SpinLockRelease(&XLogCtl->info_lck);
 
 	return lsn;
 }
 
 /*
- * SetLastWrittenLSNForBlockRange -- Set maximal LSN of written page range.
- * We maintain cache of last written LSNs with limited size and LRU replacement
- * policy. To reduce cache size we store max LSN not for each page, but for
- * bucket (1024 blocks). This cache allows to use old LSN when
- * requesting pages of unchanged or appended relations.
- *
- * rnode can be InvalidOid, in this case maxLastWrittenLsn is updated. 
- * SetLastWrittenLsn with InvalidOid
- * is used by createdb and dbase_redo functions.
+ * SetLastWrittenPageLSN -- Set maximal LSN of written page
  */
 void
-SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, Oid rnode, BlockNumber from, BlockNumber till)
+SetLastWrittenPageLSN(XLogRecPtr lsn)
 {
-	if (lsn == InvalidXLogRecPtr)
-		return;
-
-	LWLockAcquire(LastWrittenLsnLock, LW_EXCLUSIVE);
-	if (rnode == InvalidOid)
-	{
-		if (lsn > XLogCtl->maxLastWrittenLsn)
-			XLogCtl->maxLastWrittenLsn = lsn;
-	}
-	else
-	{
-		LastWrittenLsnCacheEntry* entry;
-		LastWrittenLsnCacheKey key;
-		bool found;
-		BlockNumber bucket;
-
-		key.relid = rnode;
-		for (bucket = from / LAST_WRITTEN_LSN_CACHE_BUCKET;
-			 bucket <= till / LAST_WRITTEN_LSN_CACHE_BUCKET;
-			 bucket++)
-		{
-			key.bucket = bucket;
-			entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
-			if (found)
-			{
-				if (lsn > entry->lsn)
-					entry->lsn = lsn;
-				/* Unlink from LRU list */
-				entry->next->prev = entry->prev;
-				entry->prev->next = entry->next;
-			}
-			else
-			{
-				entry->lsn = lsn;
-				if (hash_get_num_entries(lastWrittenLsnCache) > lastWrittenLsnCacheSize)
-				{
-					/* Replace least recently used entry */
-					LastWrittenLsnCacheEntry* victim = XLogCtl->lastWrittenLsnLRU.prev;
-					/* Adjust max LSN for not cached relations/chunks if needed */
-					if (victim->lsn > XLogCtl->maxLastWrittenLsn)
-						XLogCtl->maxLastWrittenLsn = victim->lsn;
-
-					victim->next->prev = victim->prev;
-					victim->prev->next = victim->next;
-					hash_search(lastWrittenLsnCache, victim, HASH_REMOVE, NULL);
-				}
-			}
-			/* Link to the head of LRU list */
-			entry->next = XLogCtl->lastWrittenLsnLRU.next;
-			entry->prev = &XLogCtl->lastWrittenLsnLRU;
-			XLogCtl->lastWrittenLsnLRU.next = entry->next->prev = entry;
-		}
-	}
-	LWLockRelease(LastWrittenLsnLock);
-}
-
-/*
- * SetLastWrittenLSNForBlock -- Set maximal LSN for block
- */
-void
-SetLastWrittenLSNForBlock(XLogRecPtr lsn, Oid rnode, BlockNumber blkno)
-{
-	SetLastWrittenLSNForBlockRange(lsn, rnode, blkno, blkno);
-}
-
-/*
- * SetLastWrittenLSNForRelation -- Set maximal LSN for relation metadata
- */
-void
-SetLastWrittenLSNForRelation(XLogRecPtr lsn, Oid rnode)
-{
-	SetLastWrittenLSNForBlock(lsn, rnode, REL_METADATA_PSEUDO_BLOCKNO);
-}
-
-/*
- * SetLastWrittenLSNForDatabase -- Set maximal LSN for the whole database
- */
-void
-SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
-{
-	SetLastWrittenLSNForBlock(lsn, InvalidOid, 0);
+	SpinLockAcquire(&XLogCtl->info_lck);
+	if (lsn > XLogCtl->lastWrittenPageLSN)
+		XLogCtl->lastWrittenPageLSN = lsn;
+	SpinLockRelease(&XLogCtl->info_lck);
 }
 
 /*

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -674,7 +674,7 @@ createdb(ParseState *pstate, const CreatedbStmt *stmt)
 
 				lsn = XLogInsert(RM_DBASE_ID,
 								 XLOG_DBASE_CREATE | XLR_SPECIAL_REL_UPDATE);
-				SetLastWrittenLSNForDatabase(lsn);
+				SetLastWrittenPageLSN(lsn);
 			}
 		}
 		table_endscan(scan);
@@ -2224,7 +2224,8 @@ dbase_redo(XLogReaderState *record)
 		 */
 		{
 			XLogRecPtr	lsn = record->EndRecPtr;
-			SetLastWrittenLSNForDatabase(lsn);
+
+			SetLastWrittenPageLSN(lsn);
 		}
 	}
 	else if (info == XLOG_DBASE_DROP)

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2058,13 +2058,6 @@ ProcessStandbyReply(XLogRecPtr	writePtr,
 	if (!am_cascading_walsender)
 		SyncRepReleaseWaiters();
 
-	/* 
-	 * walproposer use trunclateLsn instead of flushPtr for confirmed
-	 * received location, so we shouldn't update restart_lsn here.
-	 */
-	if (am_wal_proposer)
-		return;
-
 	/*
 	 * walproposer use trunclateLsn instead of flushPtr for confirmed
 	 * received location, so we shouldn't update restart_lsn here.

--- a/src/backend/storage/lmgr/lwlocknames.txt
+++ b/src/backend/storage/lmgr/lwlocknames.txt
@@ -53,4 +53,3 @@ XactTruncationLock					44
 # 45 was XactTruncationLock until removal of BackendRandomLock
 WrapLimitsVacuumLock				46
 NotifyQueueTailLock					47
-LastWrittenLsnLock					48

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -2368,16 +2368,6 @@ static struct config_int ConfigureNamesInt[] =
 	},
 
 	{
-		{"lsn_cache_size", PGC_POSTMASTER, UNGROUPED,
-			gettext_noop("Size of las written LSN cache used by Neon."),
-			NULL
-		},
-		&lastWrittenLsnCacheSize,
-		1024, 10, 1000000, /* 1024 is enough to hold 10GB database with 8Mb bucket */
-		NULL, NULL, NULL
-	},
-
-	{
 		{"temp_buffers", PGC_USERSET, RESOURCES_MEM,
 			gettext_noop("Sets the maximum number of temporary buffers used by each session."),
 			NULL,

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -32,11 +32,6 @@ extern int	sync_method;
 extern PGDLLIMPORT TimeLineID ThisTimeLineID;	/* current TLI */
 
 /*
- * Pseudo block number used to associate LSN with relation metadata (relation size)
- */
-#define REL_METADATA_PSEUDO_BLOCKNO InvalidBlockNumber
-
-/*
  * Prior to 8.4, all activity during recovery was carried out by the startup
  * process. This local variable continues to be used in many parts of the
  * code to indicate actions taken by RecoveryManagers. Other processes that
@@ -137,7 +132,6 @@ extern char *PrimaryConnInfo;
 extern char *PrimarySlotName;
 extern bool wal_receiver_create_temp_slot;
 extern bool track_wal_io_timing;
-extern int  lastWrittenLsnCacheSize;
 
 /* indirectly set via GUC system */
 extern TransactionId recoveryTargetXid;
@@ -357,11 +351,8 @@ extern XLogRecPtr GetFlushRecPtr(void);
 extern XLogRecPtr GetLastImportantRecPtr(void);
 extern void RemovePromoteSignalFiles(void);
 
-extern void SetLastWrittenLSNForBlock(XLogRecPtr lsn, Oid relfilenode, BlockNumber blkno);
-extern void SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, Oid relfilenode, BlockNumber from, BlockNumber till);
-extern void SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
-extern void SetLastWrittenLSNForRelation(XLogRecPtr lsn, Oid relfilenode);
-extern XLogRecPtr GetLastWrittenLSN(Oid relfilenode, BlockNumber blkno);
+extern void SetLastWrittenPageLSN(XLogRecPtr lsn);
+extern XLogRecPtr GetLastWrittenPageLSN(void);
 
 extern XLogRecPtr GetRedoStartLsn(void);
 


### PR DESCRIPTION
This reverts commit 7517d1cec45224841eac327cad7e0ddc81c734ff.

Revert "Large last written lsn cache (#177)"

This reverts commit 595ac69260719d8d7b43c09ab7dfd8f232542e50.