### PR TITLE
Initiaize LSN fields of feedback with UnknownXLogRecPtr instead of InvalidXLogRecPtr

### DIFF
--- a/src/backend/replication/walproposer.c
+++ b/src/backend/replication/walproposer.c
@@ -1953,6 +1953,9 @@ WalproposerShmemInit(void)
 	if (!found)
 	{
 		memset(walprop_shared, 0, WalproposerShmemSize());
+		walprop_shared->feedback.ps_writelsn = UnknownXLogRecPtr;
+		walprop_shared->feedback.ps_flushlsn = UnknownXLogRecPtr;
+		walprop_shared->feedback.ps_applylsn = UnknownXLogRecPtr;
 		SpinLockInit(&walprop_shared->mutex);
 	}
 	LWLockRelease(AddinShmemInitLock);

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -3872,6 +3872,15 @@ backpressure_lag(void)
 			LSN_FORMAT_ARGS(flushPtr),
 			LSN_FORMAT_ARGS(applyPtr));
 
+		if (writePtr == InvalidXLogRecPtr ||
+			flushPtr == InvalidXLogRecPtr ||
+			applyPtr == InvalidXLogRecPtr)
+		{
+			elog(FATAL, "Repication feedback contains invalid LSNs: write %X/%X flush %X/%X apply %X/%X",
+			LSN_FORMAT_ARGS(writePtr),
+			LSN_FORMAT_ARGS(flushPtr),
+			LSN_FORMAT_ARGS(applyPtr));
+		}
 		if ((writePtr != UnknownXLogRecPtr
 			&& max_replication_write_lag > 0
 			&& myFlushLsn > writePtr + max_replication_write_lag*MB))

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -3872,16 +3872,8 @@ backpressure_lag(void)
 			LSN_FORMAT_ARGS(flushPtr),
 			LSN_FORMAT_ARGS(applyPtr));
 
-		if (writePtr == InvalidXLogRecPtr ||
-			flushPtr == InvalidXLogRecPtr ||
-			applyPtr == InvalidXLogRecPtr)
-		{
-			elog(FATAL, "Repication feedback contains invalid LSNs: write %X/%X flush %X/%X apply %X/%X",
-			LSN_FORMAT_ARGS(writePtr),
-			LSN_FORMAT_ARGS(flushPtr),
-			LSN_FORMAT_ARGS(applyPtr));
-		}
 		if ((writePtr != UnknownXLogRecPtr
+			&& writePtr != InvalidXLogRecPtr
 			&& max_replication_write_lag > 0
 			&& myFlushLsn > writePtr + max_replication_write_lag*MB))
 		{
@@ -3889,6 +3881,7 @@ backpressure_lag(void)
 		}
 
 		if ((flushPtr != UnknownXLogRecPtr
+			&& flushPtr != InvalidXLogRecPtr
 			&& max_replication_flush_lag > 0
 			&& myFlushLsn > flushPtr + max_replication_flush_lag*MB))
 		{
@@ -3896,6 +3889,7 @@ backpressure_lag(void)
 		}
 
 		if ((applyPtr != UnknownXLogRecPtr
+			&& applyPtr != InvalidXLogRecPtr
 			&& max_replication_apply_lag > 0
 			&& myFlushLsn > applyPtr + max_replication_apply_lag*MB))
 		{


### PR DESCRIPTION
I faced with yet another backpressure problem which I can not reproduce:
just run pgbench -i -s 1000 and interrupt it some where in the middle. Then I connect to the database using psql , try to execute some create table statement and it hangs. Looking at backend status I noticed that it is in backpressure throttling state. But pageserver is idle. I wait 10 minutes but  nothing changed. 

Looks like the problem is that replication_feedback_get_lsns returns all zeroes and backpressure_lag  compares returned LSN with UnknownXLogRecPtrwhich is ~0