### PR TITLE
Remove redundant const keyword

### DIFF
--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -132,7 +132,7 @@ extern void smgr_init_standard(void);
 extern void smgr_shutdown_standard(void);
 
 // Alternative implementation of calculate_database_size()
-typedef const int64 (*dbsize_hook_type) (Oid dbOid);
+typedef int64 (*dbsize_hook_type) (Oid dbOid);
 extern PGDLLIMPORT dbsize_hook_type dbsize_hook;
 
 typedef const f_smgr *(*smgr_hook_type) (BackendId backend, RelFileNode rnode);


### PR DESCRIPTION
Everything compiles fine on our linux builds, but the compiler in our osx builds emits a `incompatible-function-pointer-types` warning:

```
/Users/runner/work/neon/neon//vendor/postgres/contrib/neon/libpagestore.c:438:15: warning: incompatible function pointer types assigning to 'dbsize_hook_type' (aka 'const long (*)(unsigned int)') from 'int64 (Oid)' (aka 'long (unsigned int)') [-Wincompatible-function-pointer-types]
4609
                dbsize_hook = zenith_dbsize;
4610
                            ^ ~~~~~~~~~~~~~
4611
1 warning generated.
4612
```

To me it looks like the `const` keyword in `typedef const int64 (*dbsize_hook_type) (Oid dbOid);` is redundant. An `int64` returned as rvalue is const anyway, it's not a pointer. So maybe the compiler on linux ignores the const and compiles this, while the compiler on osx gets confused and emits a warning. I'm not sure if it's only confused in theory, or if it's confused enough to have undefined behavior, so I'd rather correct the definition and remove the `const` keyword.

I checked that this patch fixes the warning on OSx.

Should we also fail CI on compiler warnings?