### PR TITLE
Support safekeeper auth

### DIFF
--- a/contrib/neon/walproposer.c
+++ b/contrib/neon/walproposer.c
@@ -426,11 +426,15 @@ WalProposerInitImpl(XLogRecPtr flushRecPtr, uint64 systemId)
 		safekeeper[n_safekeepers].state = SS_OFFLINE;
 		safekeeper[n_safekeepers].conn = NULL;
 
-		/*
-		 * Set conninfo to empty. We'll fill it out once later, in
-		 * `ResetConnection` as needed
-		 */
-		safekeeper[n_safekeepers].conninfo[0] = '\0';
+		{
+			int written = 0;
+			written = snprintf((char *) &safekeeper[n_safekeepers].conninfo, MAXCONNINFO,
+							   "host=%s port=%s dbname=replication options='-c ztimelineid=%s ztenantid=%s'",
+							   host, port, zenith_timeline_walproposer, zenith_tenant_walproposer);
+			if (written > MAXCONNINFO || written < 0)
+				elog(FATAL, "could not create connection string for safekeeper %s:%s", host, port);
+		}
+
 		initStringInfo(&safekeeper[n_safekeepers].outbuf);
 		safekeeper[n_safekeepers].xlogreader = XLogReaderAllocate(wal_segment_size, NULL, XL_ROUTINE(.segment_open = wal_segment_open, .segment_close = wal_segment_close), NULL);
 		if (safekeeper[n_safekeepers].xlogreader == NULL)
@@ -596,22 +600,7 @@ ResetConnection(Safekeeper *sk)
 
 	/*
 	 * Try to establish new connection
-	 *
-	 * If the connection information hasn't been filled out, we need to do
-	 * that here.
 	 */
-	if (sk->conninfo[0] == '\0')
-	{
-		int written = 0;
-		written = snprintf((char *) &sk->conninfo, MAXCONNINFO,
-				"host=%s port=%s dbname=replication options='-c ztimelineid=%s ztenantid=%s'",
-				sk->host, sk->port, zenith_timeline_walproposer, zenith_tenant_walproposer);
-		// currently connection string is not that long, but once we pass something like jwt we might overflow the buffer,
-		// so it is better to be defensive and check that everything aligns well
-		if (written > MAXCONNINFO || written < 0)
-			elog(FATAL, "could not create connection string for safekeeper %s:%s", sk->host, sk->port);
-	}
-
 	sk->conn = walprop_connect_start((char *) &sk->conninfo);
 
 	/*
@@ -1315,14 +1304,11 @@ DetermineEpochStartLsn(void)
 static bool
 WalProposerRecovery(int donor, TimeLineID timeline, XLogRecPtr startpos, XLogRecPtr endpos)
 {
-	char		conninfo[MAXCONNINFO];
 	char	   *err;
 	WalReceiverConn *wrconn;
 	WalRcvStreamOptions options;
 
-	sprintf(conninfo, "host=%s port=%s dbname=replication options='-c ztimelineid=%s ztenantid=%s'",
-			safekeeper[donor].host, safekeeper[donor].port, zenith_timeline_walproposer, zenith_tenant_walproposer);
-	wrconn = walrcv_connect(conninfo, false, "wal_proposer_recovery", &err);
+	wrconn = walrcv_connect(safekeeper[donor].conninfo, false, "wal_proposer_recovery", &err);
 	if (!wrconn)
 	{
 		ereport(WARNING,

--- a/contrib/neon/walproposer.h
+++ b/contrib/neon/walproposer.h
@@ -38,6 +38,7 @@ typedef struct WalMessage WalMessage;
 
 extern char *zenith_timeline_walproposer;
 extern char *zenith_tenant_walproposer;
+extern char *zenith_safekeeper_token_walproposer;
 
 /* Possible return values from ReadPGAsync */
 typedef enum
@@ -324,7 +325,13 @@ typedef struct Safekeeper
 {
 	char const*        host;
 	char const*        port;
-	char               conninfo[MAXCONNINFO]; /* connection info for connecting/reconnecting */
+
+	/*
+	 * connection string for connecting/reconnecting.
+	 *
+	 * May contain private information like password and should not be logged.
+	 */
+	char               conninfo[MAXCONNINFO];
 
 	/*
 	 * postgres protocol connection to the WAL acceptor


### PR DESCRIPTION
Tracking issue: https://github.com/neondatabase/neon/issues/1854

The compute node should be able to pass authentication token (per-tenant) to Safekeeper. Pageserver auth works via an environment variable (typically called `ZENITH_AUTH_KEY`) and a special substring in the connection string (e.g. `postgres://user:$ZENITH_AUTH_KEY`). We always craft Safekeeper connection strings ourselves, hence we only need to know the environment variable name (presumably the same `ZENITH_AUTH_KEY`).
