### PR TITLE
Stamp XLP_FIRST_IS_CONTRECORD only if we start writing with page offset.

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7857,14 +7857,20 @@ StartupXLOG(void)
 		{
 			int			offs = (EndRecPtr % XLOG_BLCKSZ);
 			XLogRecPtr	lastPage = EndRecPtr - offs;
+			int lastPageSize = ((lastPage % wal_segment_size) == 0) ? SizeOfXLogLongPHD : SizeOfXLogShortPHD;
 			int			idx = XLogRecPtrToBufIdx(lastPage);
 			XLogPageHeader xlogPageHdr = (XLogPageHeader) (XLogCtl->pages + idx * XLOG_BLCKSZ);
 
 			xlogPageHdr->xlp_pageaddr = lastPage;
 			xlogPageHdr->xlp_magic = XLOG_PAGE_MAGIC;
 			xlogPageHdr->xlp_tli = ThisTimeLineID;
-			xlogPageHdr->xlp_info = XLP_FIRST_IS_CONTRECORD; // FIXME
-			xlogPageHdr->xlp_rem_len = offs - SizeOfXLogShortPHD;
+			/*
+			 * If we start writing with offset from page beginning, pretend in
+			 * page header there is a record ending where actual data will
+			 * start.
+			 */
+			xlogPageHdr->xlp_rem_len = offs - lastPageSize;
+			xlogPageHdr->xlp_info = (xlogPageHdr->xlp_rem_len > 0) ? XLP_FIRST_IS_CONTRECORD : 0;
 			readOff = XLogSegmentOffset(lastPage, wal_segment_size);
 
 			elog(LOG, "Continue writing WAL at %X/%X", LSN_FORMAT_ARGS(EndRecPtr));


### PR DESCRIPTION
Without this patch, on bootstrap XLP_FIRST_IS_CONTRECORD has been always put on
header of a page where WAL writing continues. This confuses WAL decoding on
safekeepers, making them think decoding starts in the middle of a record, leading
to

2022-08-12T17:48:13.816665Z ERROR {tid=37}: query handler for 'START_WAL_PUSH postgresql://no_user:@localhost:15050' failed: failed to run ReceiveWalConn

Caused by:
    0: failed to process ProposerAcceptorMessage
    1: invalid xlog page header: unexpected XLP_FIRST_IS_CONTRECORD at 0/2CF8000