### PR TITLE
Init wal redo buffer for fpi

### DIFF
--- a/src/backend/tcop/zenith_wal_redo.c
+++ b/src/backend/tcop/zenith_wal_redo.c
@@ -633,8 +633,8 @@ ApplyRecord(StringInfo input_message)
 
 	RmgrTable[record->xl_rmid].rm_redo(reader_state);
 	/*
-	 * If there is WAL record with FPI, then no image is provided and so PushPage is not called.
-	 * We need to initialize wal_redo_buffers in this case.
+	 * If no base image of the page was provided by PushPage, initialize wal_redo_buffer here.
+	 * The first WAL record must initialize the page in that case.
 	 */
 	if (BufferIsInvalid(wal_redo_buffer))
 	{

--- a/src/backend/tcop/zenith_wal_redo.c
+++ b/src/backend/tcop/zenith_wal_redo.c
@@ -100,8 +100,9 @@ static BufferTag target_redo_tag;
 
 /*
  * Buffer with target WAL redo page.
- * We need to pin this buffer i memory but we c an not just call ReadBuffer because
- * in some contexts it is assumed that buffer is not locked.
+ * We must not evict this page from the buffer pool, but we cannot just keep it pinned because
+ * some WAL redo functions expect the page to not be pinned. So we have a special check in
+ * localbuf.c to prevent this buffer from being evicted.
  */
 Buffer		wal_redo_buffer;
 bool		am_wal_redo_postgres;

--- a/src/backend/tcop/zenith_wal_redo.c
+++ b/src/backend/tcop/zenith_wal_redo.c
@@ -572,7 +572,6 @@ PushPage(StringInfo input_message)
 	content = pq_getmsgbytes(input_message, BLCKSZ);
 
 	buf = ReadBufferWithoutRelcache(rnode, forknum, blknum, RBM_ZERO_AND_LOCK, NULL);
-	Assert(!BufferIsInvalid(buf));
 	wal_redo_buffer = buf;
 	page = BufferGetPage(buf);
 	memcpy(page, content, BLCKSZ);


### PR DESCRIPTION
refer https://github.com/neondatabase/neon/issues/1915

We are using very small buffer cache and inmem file i wal redo postgres to minimize their restart time.
Right now we are protected target page using wal_redo_buffer variable.
This hack looks pretty ugly but I do not know better solution.
The problem is that now wal_redo_buffer is assigned only when base image is provided for page reconstruction.
But if wal records contains FPI, base image is not needed. In this case wal_redo_buffer is not initialized and so is not protected from eviction. This PR fixing this problem.

This bug cause index page corruption in ketteq project.

Replaces #179