### PR TITLE
walproposer: do not send pageserver connstring with START_WAL_PUSH

### DIFF
--- a/contrib/neon/libpagestore.c
+++ b/contrib/neon/libpagestore.c
@@ -417,12 +417,6 @@ pg_init_libpagestore(void)
 	zenith_timeline_walproposer = zenith_timeline;
 	zenith_tenant_walproposer = zenith_tenant;
 
-	/*
-	 * Walproposer instructs safekeeper which pageserver to use for
-	 * replication
-	 */
-	zenith_pageserver_connstring_walproposer = page_server_connstring;
-
 	if (wal_redo)
 	{
 		neon_log(PageStoreTrace, "set inmem_smgr hook");

--- a/contrib/neon/walproposer.c
+++ b/contrib/neon/walproposer.c
@@ -73,7 +73,6 @@ bool		am_wal_proposer;
 
 char	   *zenith_timeline_walproposer = NULL;
 char	   *zenith_tenant_walproposer = NULL;
-char	   *zenith_pageserver_connstring_walproposer = NULL;
 
 /* Declared in walproposer.h, defined here, initialized in libpqwalproposer.c */
 WalProposerFunctionsType *WalProposerFunctions = NULL;
@@ -879,21 +878,13 @@ HandleConnectionEvent(Safekeeper *sk)
 static void
 SendStartWALPush(Safekeeper *sk)
 {
-	char *query = NULL;
-	if (zenith_pageserver_connstring_walproposer != NULL) {
-		query = psprintf("START_WAL_PUSH %s", zenith_pageserver_connstring_walproposer);
-	} else {
-		query = psprintf("START_WAL_PUSH");
-	}
-	if (!walprop_send_query(sk->conn, query))
+	if (!walprop_send_query(sk->conn, "START_WAL_PUSH"))
 	{
-		pfree(query);
 		elog(WARNING, "Failed to send 'START_WAL_PUSH' query to safekeeper %s:%s: %s",
 			sk->host, sk->port, walprop_error_message(sk->conn));
 		ShutdownConnection(sk);
 		return;
 	}
-	pfree(query);
 	sk->state = SS_WAIT_EXEC_RESULT;
 	UpdateEventSet(sk, WL_SOCKET_READABLE);
 }

--- a/contrib/neon/walproposer.h
+++ b/contrib/neon/walproposer.h
@@ -38,7 +38,6 @@ typedef struct WalMessage WalMessage;
 
 extern char *zenith_timeline_walproposer;
 extern char *zenith_tenant_walproposer;
-extern char	*zenith_pageserver_connstring_walproposer;
 
 /* Possible return values from ReadPGAsync */
 typedef enum


### PR DESCRIPTION
It is not used anymore since https://github.com/neondatabase/neon/pull/1872