### PR TITLE
Pin pages with speculative insert tuples to prevent their reconstruction because spec_token is not wal logged

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -9001,7 +9001,7 @@ heap_xlog_insert(XLogReaderState *record)
 
 	XLogRecGetBlockTag(record, 0, &target_node, NULL, &blkno);
 	ItemPointerSetBlockNumber(&target_tid, blkno);
-	ItemPointerSetOffsetNumber(&target_tid, (xlrec->flags & XLH_INSERT_IS_SPECULATIVE) ? SpecTokenOffsetNumber : xlrec->offnum);
+	ItemPointerSetOffsetNumber(&target_tid, xlrec->offnum);
 
 	/*
 	 * The visibility map may need to be fixed even if the heap page is

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -5999,8 +5999,15 @@ heap_abort_speculative(Relation relation, ItemPointer tid)
 		elog(ERROR, "attempted to kill a non-speculative tuple");
 	Assert(!HeapTupleHeaderIsHeapOnly(tp.t_data));
 
+    /*
+     * NEON: release buffer pinned by heap_insert
+     *
+     * This function is also used on the toast tuples of an aborted speculative
+     * insertion. For those, there is no token on the tuple, and we didn' t keep
+     * the pin. 
+      */
 	if (HeapTupleHeaderIsSpeculative(tp.t_data))
-		ReleaseBuffer(buffer);  /* NEON: release buffer pinned by heap_insert */
+		ReleaseBuffer(buffer);  
 
 	/*
 	 * No need to check for serializable conflicts here.  There is never a

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2261,9 +2261,9 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 	if (options & HEAP_INSERT_SPECULATIVE)
 	{
 		/*
-		 * NEON: speculative token is not stored i WAL, so we are not able to reconstruct it from hep insert WAL record.
-		 * So we have to pin this page until end of speculative insert.
-		 * Page will be unpinned by heapam_tuple_complete_speculative
+		 * NEON: speculative token is not stored in WAL, so if the page is evicted
+		 * from the buffer cache, the token will be lost. To prevent that, we keep the
+		 * buffer pinned. It will be unpinned in heapam_tuple_finish/abort_speculative.
 		 */
 		LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
 	}

--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -5875,7 +5875,6 @@ heap_finish_speculative(Relation relation, ItemPointer tid)
 
 	buffer = ReadBuffer(relation, ItemPointerGetBlockNumber(tid));
 	LockBuffer(buffer, BUFFER_LOCK_EXCLUSIVE);
-	ReleaseBuffer(buffer); /* NEON: release buffer pinned by heap_insert */
 	page = (Page) BufferGetPage(buffer);
 
 	offnum = ItemPointerGetOffsetNumber(tid);
@@ -5927,6 +5926,7 @@ heap_finish_speculative(Relation relation, ItemPointer tid)
 
 	END_CRIT_SECTION();
 
+	ReleaseBuffer(buffer); /* NEON: release buffer pinned by heap_insert */
 	UnlockReleaseBuffer(buffer);
 }
 


### PR DESCRIPTION
refer #2587