### PR TITLE
Fix shared memory initialization for last written LSN cache

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8978,7 +8978,7 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 void
 SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
-	if (lsn == InvalidXLogRecPtr)
+	if (lsn == InvalidXLogRecPtr || n_blocks == 0)
 		return;
 
 	LWLockAcquire(LastWrittenLsnLock, LW_EXCLUSIVE);
@@ -8997,8 +8997,7 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber for
 		BlockNumber end_bucket;   /* exclusive */
 
 		start_bucket = from / LAST_WRITTEN_LSN_CACHE_BUCKET;
-		end_bucket = n_blocks == 0
-			? start_bucket : (from + n_blocks + LAST_WRITTEN_LSN_CACHE_BUCKET - 1) / LAST_WRITTEN_LSN_CACHE_BUCKET;
+		end_bucket = (from + n_blocks + LAST_WRITTEN_LSN_CACHE_BUCKET - 1) / LAST_WRITTEN_LSN_CACHE_BUCKET;
 
 		key.rnode = rnode;
 		key.forkNum = forknum;

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -5247,7 +5247,7 @@ XLOGShmemInit(void)
 
 
 	XLogCtl = (XLogCtlData *)
-		ShmemInitStruct("XLOG Ctl", XLOGShmemSize(), &foundXLog);
+		ShmemInitStruct("XLOG Ctl", XLOGCtlShmemSize(), &foundXLog);
 
 	{
 		static HASHCTL info;
@@ -8976,7 +8976,7 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
  * SetLastWrittenLsn with dummy rnode is used by createdb and dbase_redo functions.
  */
 void
-SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber till)
+SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
 	if (lsn == InvalidXLogRecPtr)
 		return;
@@ -8993,12 +8993,16 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber for
 		BufferTag key;
 		bool found;
 		BlockNumber bucket;
+		BlockNumber start_bucket; /* inclusive */
+		BlockNumber end_bucket;   /* exclusive */
+
+		start_bucket = from / LAST_WRITTEN_LSN_CACHE_BUCKET;
+		end_bucket = n_blocks == 0
+			? start_bucket : (from + n_blocks + LAST_WRITTEN_LSN_CACHE_BUCKET - 1) / LAST_WRITTEN_LSN_CACHE_BUCKET;
 
 		key.rnode = rnode;
 		key.forkNum = forknum;
-		for (bucket = from / LAST_WRITTEN_LSN_CACHE_BUCKET;
-			 bucket <= till / LAST_WRITTEN_LSN_CACHE_BUCKET;
-			 bucket++)
+		for (bucket = start_bucket; bucket < end_bucket; bucket++)
 		{
 			key.blockNum = bucket;
 			entry = hash_search(lastWrittenLsnCache, &key, HASH_ENTER, &found);
@@ -9036,7 +9040,7 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber for
 void
 SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 {
-	SetLastWrittenLSNForBlockRange(lsn, rnode, forknum, blkno, blkno);
+	SetLastWrittenLSNForBlockRange(lsn, rnode, forknum, blkno, 1);
 }
 
 /*

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -358,7 +358,7 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 extern void RemovePromoteSignalFiles(void);
 
 extern void SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-extern void SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber till);
+extern void SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
 extern void SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
 extern void SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
 extern XLogRecPtr GetLastWrittenLSN(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);


### PR DESCRIPTION
Replace (from,till) with (from,n_blocks) for SetLastWrittenLSNForBlockRange function