### PR TITLE
Stamp XLP_FIRST_IS_CONTRECORD only if we start writing with page offset.

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -1525,17 +1525,23 @@ FinishWalRecovery(void)
 		}
 		else
 		{
-			int len = endOfLog % XLOG_BLCKSZ;
-			char *page = palloc0(len);
-			XLogRecPtr pageBeginPtr = endOfLog - (endOfLog % XLOG_BLCKSZ);
+			int offs = endOfLog % XLOG_BLCKSZ;
+			char *page = palloc0(offs);
+			XLogRecPtr pageBeginPtr = endOfLog - offs;
+			int lastPageSize = ((pageBeginPtr % wal_segment_size) == 0) ? SizeOfXLogLongPHD : SizeOfXLogShortPHD;
 
 			XLogPageHeader xlogPageHdr = (XLogPageHeader) (page);
 
 			xlogPageHdr->xlp_pageaddr = pageBeginPtr;
 			xlogPageHdr->xlp_magic = XLOG_PAGE_MAGIC;
 			xlogPageHdr->xlp_tli = recoveryTargetTLI;
-			xlogPageHdr->xlp_info = XLP_FIRST_IS_CONTRECORD; // FIXME
-			xlogPageHdr->xlp_rem_len = (endOfLog % XLOG_BLCKSZ) - SizeOfXLogShortPHD;
+			/*
+			 * If we start writing with offset from page beginning, pretend in
+			 * page header there is a record ending where actual data will
+			 * start.
+			 */
+			xlogPageHdr->xlp_rem_len = offs - lastPageSize;
+			xlogPageHdr->xlp_info = (xlogPageHdr->xlp_rem_len > 0) ? XLP_FIRST_IS_CONTRECORD : 0;
 			readOff = XLogSegmentOffset(pageBeginPtr, wal_segment_size);
 
 			result->lastPageBeginPtr = pageBeginPtr;


### PR DESCRIPTION
Without this patch, on bootstrap XLP_FIRST_IS_CONTRECORD has been always put on header of a page where WAL writing continues. This confuses WAL decoding on safekeepers, making it think decoding starts in the middle of a record, leading to

 2022-08-12T17:48:13.816665Z ERROR {tid=37}: query handler for 'START_WAL_PUSH postgresql://no_user:@localhost:15050' failed: failed to run ReceiveWalConn

 Caused by:
    0: failed to process ProposerAcceptorMessage
    1: invalid xlog page header: unexpected XLP_FIRST_IS_CONTRECORD at 0/2CF8000

Rebase of a1af529d08497f for v14.