### PR TITLE
Fix expected results for regression tests

### DIFF
--- a/src/test/regress/expected/sysviews.out
+++ b/src/test/regress/expected/sysviews.out
@@ -8,13 +8,13 @@
 -- but even a trivial check of count(*) will exercise the normal code path
 -- through the SRF.
 select count(*) >= 0 as ok from pg_available_extension_versions;
- ok
+ ok 
 ----
  t
 (1 row)
 
 select count(*) >= 0 as ok from pg_available_extensions;
- ok
+ ok 
 ----
  t
 (1 row)
@@ -23,27 +23,27 @@ select count(*) >= 0 as ok from pg_available_extensions;
 -- we test only the existence and basic condition of TopMemoryContext.
 select name, ident, parent, level, total_bytes >= free_bytes
   from pg_backend_memory_contexts where level = 0;
-       name       | ident | parent | level | ?column?
+       name       | ident | parent | level | ?column? 
 ------------------+-------+--------+-------+----------
  TopMemoryContext |       |        |     0 | t
 (1 row)
 
 -- At introduction, pg_config had 23 entries; it may grow
 select count(*) > 20 as ok from pg_config;
- ok
+ ok 
 ----
  t
 (1 row)
 
 -- We expect no cursors in this test; see also portals.sql
 select count(*) = 0 as ok from pg_cursors;
- ok
+ ok 
 ----
  t
 (1 row)
 
 select count(*) >= 0 as ok from pg_file_settings;
- ok
+ ok 
 ----
  t
 (1 row)
@@ -51,7 +51,7 @@ select count(*) >= 0 as ok from pg_file_settings;
 -- There will surely be at least one rule, with no errors.
 select count(*) > 0 as ok, count(*) FILTER (WHERE error IS NOT NULL) = 0 AS no_err
   from pg_hba_file_rules;
- ok | no_err
+ ok | no_err 
 ----+--------
  t  | t
 (1 row)
@@ -59,49 +59,49 @@ select count(*) > 0 as ok, count(*) FILTER (WHERE error IS NOT NULL) = 0 AS no_e
 -- There may be no rules, and there should be no errors.
 select count(*) >= 0 as ok, count(*) FILTER (WHERE error IS NOT NULL) = 0 AS no_err
   from pg_ident_file_mappings;
- ok | no_err
+ ok | no_err 
 ----+--------
  t  | t
 (1 row)
 
 -- There will surely be at least one active lock
 select count(*) > 0 as ok from pg_locks;
- ok
+ ok 
 ----
  t
 (1 row)
 
 -- We expect no prepared statements in this test; see also prepare.sql
 select count(*) = 0 as ok from pg_prepared_statements;
- ok
+ ok 
 ----
  t
 (1 row)
 
 -- See also prepared_xacts.sql
 select count(*) >= 0 as ok from pg_prepared_xacts;
- ok
+ ok 
 ----
  t
 (1 row)
 
 -- There will surely be at least one SLRU cache
 select count(*) > 0 as ok from pg_stat_slru;
- ok
+ ok 
 ----
  t
 (1 row)
 
 -- There must be only one record
 select count(*) = 1 as ok from pg_stat_wal;
- ok
+ ok 
 ----
  t
 (1 row)
 
 -- We expect no walreceiver running in this test
 select count(*) = 0 as ok from pg_stat_wal_receiver;
- ok
+ ok 
 ----
  t
 (1 row)
@@ -109,7 +109,7 @@ select count(*) = 0 as ok from pg_stat_wal_receiver;
 -- This is to record the prevailing planner enable_foo settings during
 -- a regression test run.
 select name, setting from pg_settings where name like 'enable%';
-              name              | setting
+              name              | setting 
 --------------------------------+---------
  enable_async_append            | on
  enable_bitmapscan              | on
@@ -141,13 +141,13 @@ select name, setting from pg_settings where name like 'enable%';
 -- (At the time of writing, the actual counts are around 38 because of
 -- zones using fractional GMT offsets, so this is a pretty loose test.)
 select count(distinct utc_offset) >= 24 as ok from pg_timezone_names;
- ok
+ ok 
 ----
  t
 (1 row)
 
 select count(distinct utc_offset) >= 24 as ok from pg_timezone_abbrevs;
- ok
+ ok 
 ----
  t
 (1 row)
@@ -155,14 +155,14 @@ select count(distinct utc_offset) >= 24 as ok from pg_timezone_abbrevs;
 -- Let's check the non-default timezone abbreviation sets, too
 set timezone_abbreviations = 'Australia';
 select count(distinct utc_offset) >= 24 as ok from pg_timezone_abbrevs;
- ok
+ ok 
 ----
  t
 (1 row)
 
 set timezone_abbreviations = 'India';
 select count(distinct utc_offset) >= 24 as ok from pg_timezone_abbrevs;
- ok
+ ok 
 ----
  t
 (1 row)


### PR DESCRIPTION
Revert accidentally committed in https://github.com/neondatabase/postgres/commit/b66b5b6ebbd51cfd94c802d53e7276e830d1ef3e changes from `src/test/regress/expected/sysviews.out` .


Found in https://github.com/neondatabase/neon/pull/2809