### PR TITLE
Revert handling of UNLOGGED tables on compute side v14

### DIFF
--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -27,7 +27,6 @@
 #include "access/xlog.h"
 #include "catalog/catalog.h"
 #include "catalog/heap.h"
-#include "catalog/index.h"
 #include "catalog/pg_am.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_statistic_ext.h"
@@ -47,8 +46,6 @@
 #include "rewrite/rewriteManip.h"
 #include "statistics/statistics.h"
 #include "storage/bufmgr.h"
-#include "storage/buf_internals.h"
-#include "storage/lmgr.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/partcache.h"
@@ -83,39 +80,6 @@ static void set_baserel_partition_key_exprs(Relation relation,
 static void set_baserel_partition_constraint(Relation relation,
 											 RelOptInfo *rel);
 
-static bool
-is_index_valid(Relation index, LOCKMODE lmode)
-{
-	if (!index->rd_index->indisvalid)
-		return false;
-
-	if (index->rd_rel->relpersistence == RELPERSISTENCE_UNLOGGED)
-	{
-		while (true)
-		{
-			Buffer metapage = ReadBuffer(index, 0);
-			bool isNew = PageIsNew(BufferGetPage(metapage));
-			ReleaseBuffer(metapage);
-			if (isNew)
-			{
-				Relation heap;
-				if (lmode != ExclusiveLock)
-				{
-					UnlockRelation(index, lmode);
-					LockRelation(index, ExclusiveLock);
-					lmode = ExclusiveLock;
-					continue;
-				}
-				DropRelFileNodesAllBuffers(&index->rd_smgr, 1);
-				heap = RelationIdGetRelation(index->rd_index->indrelid);
-				index->rd_indam->ambuild(heap, index, BuildIndexInfo(index));
-				RelationClose(heap);
-			}
-			break;
-		}
-	}
-	return true;
-}
 
 /*
  * get_relation_info -
@@ -257,7 +221,7 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 			 * still needs to insert into "invalid" indexes, if they're marked
 			 * indisready.
 			 */
-			if (!is_index_valid(indexRelation, lmode))
+			if (!index->indisvalid)
 			{
 				index_close(indexRelation, NoLock);
 				continue;

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -490,13 +490,6 @@ mdopenfork(SMgrRelation reln, ForkNumber forknum, int behavior)
 
 	fd = PathNameOpenFile(path, O_RDWR | PG_BINARY);
 
-	/*
-	 * NEON: unlogged relation files are lost after compute restart - we need to implicitly recreate them
-	 * to allow data insertion
-	 */
-	if (fd < 0 && (behavior & EXTENSION_CREATE))
-		fd = PathNameOpenFile(path, O_RDWR | O_CREAT | PG_BINARY);
-
 	if (fd < 0)
 	{
 		if ((behavior & EXTENSION_RETURN_NULL) &&
@@ -659,23 +652,9 @@ mdread(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 										reln->smgr_rnode.node.relNode,
 										reln->smgr_rnode.backend);
 
-	/* NEON: md smgr is used in Neon for unlogged and temp relations.
-	 * After compute node restart their data is deleted but unlogged tables are still present in system catalog.
-	 * This is a difference with Vanilla Postgres where unlogged relations are truncated only after abnormal termination.
-	 * To avoid "could not open file" we have to use EXTENSION_RETURN_NULL hear instead of EXTENSION_FAIL
-	 */
 	v = _mdfd_getseg(reln, forknum, blocknum, false,
-					 RelFileNodeBackendIsTemp(reln->smgr_rnode)
-					 ? EXTENSION_FAIL | EXTENSION_CREATE_RECOVERY
-					 : EXTENSION_RETURN_NULL);
-	if (v == NULL)
-	{
-		char* path = relpath(reln->smgr_rnode, forknum);
-		(void)PathNameOpenFile(path, O_RDWR | O_CREAT | PG_BINARY);
-		pfree(path);
-		MemSet(buffer, 0, BLCKSZ);
-		return;
-	}
+					 EXTENSION_FAIL | EXTENSION_CREATE_RECOVERY);
+
 	seekpos = (off_t) BLCKSZ * (blocknum % ((BlockNumber) RELSEG_SIZE));
 
 	Assert(seekpos < (off_t) BLCKSZ * RELSEG_SIZE);
@@ -796,13 +775,7 @@ mdnblocks(SMgrRelation reln, ForkNumber forknum)
 	BlockNumber nblocks;
 	BlockNumber segno;
 
-	/* NEON: md smgr is used in Neon for unlogged and temp relations.
-	 * After compute node restart their data is deleted but unlogged tables are still present in system catalog.
-	 * This is a difference with Vanilla Postgres where unlogged relations are truncated only after abnormal termination.
-	 * To avoid "could not open file" we have to use EXTENSION_RETURN_NULL hear instead of EXTENSION_FAIL
-	 */
-	if (!mdopenfork(reln, forknum, RelFileNodeBackendIsTemp(reln->smgr_rnode) ? EXTENSION_FAIL : EXTENSION_RETURN_NULL))
-		return 0;
+	mdopenfork(reln, forknum, EXTENSION_FAIL);
 
 	/* mdopen has opened the first segment */
 	Assert(reln->md_num_open_segs[forknum] > 0);


### PR DESCRIPTION
They will be handled in pageserver, ref https://github.com/neondatabase/neon/pull/3706