### PR TITLE
Define NEON_SMGR in smgr.h to make it possible for extensions to use extended Neon SMGR API

### DIFF
--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -21,6 +21,12 @@
 struct f_smgr;
 
 /*
+ * Neon: extended SMGR API.
+ * This define can be used by extensions to determine that them are built for Neon.
+ */
+#define NEON_SMGR 1
+
+/*
  * smgr.c maintains a table of SMgrRelation objects, which are essentially
  * cached file handles.  An SMgrRelation is created (if not already present)
  * by smgropen(), and destroyed by smgrclose().  Note that neither of these


### PR DESCRIPTION
See https://neondb.slack.com/archives/C036U0GRMRB/p1689148023067319
