### PR TITLE
Check replication write lag not only in XLogInsert but also in XLogBeginInsert

### DIFF
--- a/src/backend/access/transam/xloginsert.c
+++ b/src/backend/access/transam/xloginsert.c
@@ -167,6 +167,9 @@ XLogBeginInsert(void)
 	if (begininsert_called)
 		elog(ERROR, "XLogBeginInsert was already called");
 
+	if (delay_backend_us != NULL && delay_backend_us() > 0)
+		InterruptPending = true;
+
 	begininsert_called = true;
 }
 


### PR DESCRIPTION
I have found one more problem with WAL throttling. Right now we check it only in XLogInsert
But generic WAL records are inserted using XLogBeginInsert
As a result extensions which use generic wal records (like our pg_embedding or pgvector) can easily exceed max_replicatopn_write_lag and cause timeout in wait_for_lsn. 
I have created yet another pair of PRs (for both version of Postgres).