### PR TITLE
Update WAL buffers when restoring WAL at compute needed for LR

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -13760,7 +13760,10 @@ XLogUpdateWalBuffers(char* data, XLogRecPtr start, size_t len)
 		/* Last page of the segment is present in WAL buffers */
 		char* page = &XLogCtl->pages[idx * XLOG_BLCKSZ];
 		size_t overlap = end - pagebegptr;
-		memcpy(page, data + len - overlap, overlap);
+		if (overlap <= len)
+			memcpy(page, data + len - overlap, overlap);
+		else
+			memcpy(page + overlap - len, data, len);
 	}
 	LWLockRelease(WALBufMappingLock);
 }

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -377,6 +377,8 @@ extern void SetWalWriterSleeping(bool sleeping);
 extern void StartupRequestWalReceiverRestart(void);
 extern void XLogRequestWalReceiverReply(void);
 
+extern void XLogUpdateWalBuffers(char* data, XLogRecPtr start, size_t len);
+
 extern void assign_max_wal_size(int newval, void *extra);
 extern void assign_checkpoint_completion_target(double newval, void *extra);
 


### PR DESCRIPTION
See https://neondb.slack.com/archives/C04DGM6SMTM/p1698226491736459