### PR TITLE
Allow to set some PGC_SUSET GUCs from db owner

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -246,6 +246,10 @@ static bool check_primary_slot_name(char **newval, void **extra, GucSource sourc
 static bool check_default_with_oids(bool *newval, void **extra, GucSource source);
 
 
+#define ALLOWED_GUCS_LEN 3
+static const char *const allowed_gucs[] = {
+"anon.salt", "anon.sourceschema", "anon.algorithm"};
+
 // Check if the user is a database owner and if the guc is in the allowed list
 // If both of these are true then the user is allowed to set the guc in PGC_SUSET context
 //
@@ -254,17 +258,15 @@ static bool
 neon_db_owner_allowed_guc(const char *name)
 {
 	bool allowed = false;
+	int i = 0;
 
 	if (name == NULL)
 		return false;
 
 	elog(DEBUG1, "test neon_db_owner_allowed_guc: %s", name);
 
-	#define ALLOWED_GUCS_LEN 3
-	const char* allowed_gucs[ALLOWED_GUCS_LEN] = {"anon.salt", "anon.sourceschema", "anon.algorithm"};
-
 	// First check that the guc is in the allowed list
-	for (int i = 0; i < ALLOWED_GUCS_LEN; i++)
+	for (i = 0; i < ALLOWED_GUCS_LEN; i++)
 	{
 		if (strcmp(name, allowed_gucs[i]) == 0)
 		{


### PR DESCRIPTION
Working on anon ext support (https://github.com/neondatabase/neon/pull/6272), I bumped into superuser only GUCs, ie.
i.e.

  DefineCustomStringVariable
  (
    "anon.salt",
    "The salt value used for the pseudonymizing functions",
    "",
    &guc_anon_salt,
    "",
    PGC_SUSET,
    GUC_SUPERUSER_ONLY,
[documentation](https://postgresql-anonymizer.readthedocs.io/en/latest/configure/#anonsalt)

We don't provide superuser access in neon, only neon_superuser.
So it is impossible for clients to use this extension with [dynamic masking](https://postgresql-anonymizer.readthedocs.io/en/latest/dynamic_masking/).
It is not secure to simply change it to PGC_USERSET.

I propose to allow some PGC_SUSET GUCs to be set by db_owner.

This is not the most beautiful solution, but it seem to work.