### PR TITLE
Allow publications FOR ALL TABLES to neon_superuser

### DIFF
--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -835,7 +835,7 @@ CreatePublication(ParseState *pstate, CreatePublicationStmt *stmt)
 								   &schemaidlist);
 
 		/* FOR TABLES IN SCHEMA requires superuser */
-		if (schemaidlist != NIL && !superuser())
+		if (schemaidlist != NIL && !superuser() && !neon_superuser())
 			ereport(ERROR,
 					errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					errmsg("must be superuser to create FOR TABLES IN SCHEMA publication"));

--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -731,10 +731,8 @@ CheckPubRelationColumnList(char *pubname, List *tables,
 static bool
 is_neon_superuser(void)
 {
-	char *name = GetUserNameFromId(GetCurrentRoleId(), true /*noerr*/);
-	bool result = strcmp(name, "neon_superuser") == 0;
-	pfree(name);
-	return result;
+	Oid neon_superuser_oid = get_role_oid("neon_superuser", true /*missing_ok*/);
+	return neon_superuser_oid != InvalidOid && has_privs_of_role(GetCurrentRoleId(), neon_superuser_oid);
 }
 
 /*
@@ -835,7 +833,7 @@ CreatePublication(ParseState *pstate, CreatePublicationStmt *stmt)
 								   &schemaidlist);
 
 		/* FOR TABLES IN SCHEMA requires superuser */
-		if (schemaidlist != NIL && !superuser() && !neon_superuser())
+		if (schemaidlist != NIL && !superuser() && !is_neon_superuser())
 			ereport(ERROR,
 					errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 					errmsg("must be superuser to create FOR TABLES IN SCHEMA publication"));

--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -732,7 +732,9 @@ static bool
 is_neon_superuser(void)
 {
 	char *name = GetUserNameFromId(GetCurrentRoleId(), true /*noerr*/);
-	return strcmp(name, "neon_superuser") == 0;
+	bool result = strcmp(name, "neon_superuser") == 0;
+	pfree(name);
+	return result;
 }
 
 /*

--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -728,6 +728,13 @@ CheckPubRelationColumnList(char *pubname, List *tables,
 	}
 }
 
+bool
+is_neon_superuser(void)
+{
+	char *name = GetUserNameFromId(GetCurrentRoleId(), true /*noerr*/);
+	return strcmp(name, "neon_superuser") == 0;
+}
+
 /*
  * Create new publication.
  */
@@ -755,7 +762,7 @@ CreatePublication(ParseState *pstate, CreatePublicationStmt *stmt)
 					   get_database_name(MyDatabaseId));
 
 	/* FOR ALL TABLES requires superuser */
-	if (stmt->for_all_tables && !superuser())
+	if (stmt->for_all_tables && !superuser() && !is_neon_superuser())
 		ereport(ERROR,
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser to create FOR ALL TABLES publication")));

--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -728,7 +728,7 @@ CheckPubRelationColumnList(char *pubname, List *tables,
 	}
 }
 
-bool
+static bool
 is_neon_superuser(void)
 {
 	char *name = GetUserNameFromId(GetCurrentRoleId(), true /*noerr*/);


### PR DESCRIPTION
Addresses https://github.com/neondatabase/neon/issues/6229

Currently we don't allow anyone at all to create a publication for all tables as it's only allowed for superusers. We have our neon_superuser which should also be allowed to make such publications. 