### PR TITLE
Add smgropen_rp to preserve compatibility with existed extensions

### DIFF
--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -637,7 +637,7 @@ heapam_relation_copy_data(Relation rel, const RelFileLocator *newrlocator)
 {
 	SMgrRelation dstrel;
 
-	dstrel = smgropen(*newrlocator, rel->rd_backend, rel->rd_rel->relpersistence);
+	dstrel = smgropen_rp(*newrlocator, rel->rd_backend, rel->rd_rel->relpersistence);
 
 	/*
 	 * Since we copy the file directly without looking at the shared buffers,

--- a/src/backend/access/transam/xlogprefetcher.c
+++ b/src/backend/access/transam/xlogprefetcher.c
@@ -724,7 +724,7 @@ XLogPrefetcherNextBlock(uintptr_t pgsr_private, XLogRecPtr *lsn)
 			 *
 			 * Only permanent relations are WAL-logged, so RELPERSISTENCE_PERMANENT.
 			 */
-			reln = smgropen(block->rlocator, InvalidBackendId, RELPERSISTENCE_PERMANENT);
+			reln = smgropen(block->rlocator, InvalidBackendId);
 
 			/*
 			 * If the relation file doesn't exist on disk, for example because

--- a/src/backend/access/transam/xlogutils.c
+++ b/src/backend/access/transam/xlogutils.c
@@ -508,7 +508,7 @@ XLogReadBufferExtended(RelFileLocator rlocator, ForkNumber forknum,
 	}
 
 	/* Open the relation at smgr level */
-	smgr = smgropen(rlocator, InvalidBackendId, RELPERSISTENCE_PERMANENT);
+	smgr = smgropen(rlocator, InvalidBackendId);
 
 	/*
 	 * Create the target file if it doesn't already exist.  This lets us cope

--- a/src/backend/catalog/storage.c
+++ b/src/backend/catalog/storage.c
@@ -145,7 +145,7 @@ RelationCreateStorage(RelFileLocator rlocator, char relpersistence,
 			return NULL;		/* placate compiler */
 	}
 
-	srel = smgropen(rlocator, backend, relpersistence);
+	srel = smgropen_rp(rlocator, backend, relpersistence);
 	smgrcreate(srel, MAIN_FORKNUM, false);
 
 	if (needs_wal)
@@ -680,7 +680,7 @@ smgrDoPendingDeletes(bool isCommit)
 			{
 				SMgrRelation srel;
 
-				srel = smgropen(pending->rlocator, pending->backend, 0);
+				srel = smgropen_rp(pending->rlocator, pending->backend, 0);
 
 				/* allocate the initial array, or extend it, if needed */
 				if (maxrels == 0)
@@ -761,7 +761,7 @@ smgrDoPendingSyncs(bool isCommit, bool isParallelWorker)
 		BlockNumber total_blocks = 0;
 		SMgrRelation srel;
 
-		srel = smgropen(pendingsync->rlocator, InvalidBackendId, 0);
+		srel = smgropen_rp(pendingsync->rlocator, InvalidBackendId, 0);
 
 		/*
 		 * We emit newpage WAL records for smaller relations.
@@ -970,7 +970,7 @@ smgr_redo(XLogReaderState *record)
 		xl_smgr_create *xlrec = (xl_smgr_create *) XLogRecGetData(record);
 		SMgrRelation reln;
 
-		reln = smgropen(xlrec->rlocator, InvalidBackendId, RELPERSISTENCE_PERMANENT);
+		reln = smgropen(xlrec->rlocator, InvalidBackendId);
 		smgrcreate(reln, xlrec->forkNum, true);
 	}
 	else if (info == XLOG_SMGR_TRUNCATE)
@@ -983,7 +983,7 @@ smgr_redo(XLogReaderState *record)
 		int			nforks = 0;
 		bool		need_fsm_vacuum = false;
 
-		reln = smgropen(xlrec->rlocator, InvalidBackendId, RELPERSISTENCE_PERMANENT);
+		reln = smgropen(xlrec->rlocator, InvalidBackendId);
 
 		/*
 		 * Forcibly create relation if it doesn't exist (which suggests that

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -276,7 +276,7 @@ ScanSourceDatabasePgClass(Oid tbid, Oid dbid, char *srcpath)
 	rlocator.dbOid = dbid;
 	rlocator.relNumber = relfilenumber;
 
-	smgr = smgropen(rlocator, InvalidBackendId, RELPERSISTENCE_PERMANENT);
+	smgr = smgropen(rlocator, InvalidBackendId);
 	nblocks = smgrnblocks(smgr, MAIN_FORKNUM);
 	smgrclose(smgr);
 

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -357,7 +357,7 @@ fill_seq_with_data(Relation rel, HeapTuple tuple)
 	{
 		SMgrRelation srel;
 
-		srel = smgropen(rel->rd_locator, InvalidBackendId, rel->rd_rel->relpersistence);
+		srel = smgropen_rp(rel->rd_locator, InvalidBackendId, rel->rd_rel->relpersistence);
 		smgrcreate(srel, INIT_FORKNUM, false);
 		log_smgrcreate(&rel->rd_locator, INIT_FORKNUM);
 		fill_seq_fork_with_data(rel, tuple, INIT_FORKNUM);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14795,7 +14795,7 @@ index_copy_data(Relation rel, RelFileLocator newrlocator)
 {
 	SMgrRelation dstrel;
 
-	dstrel = smgropen(newrlocator, rel->rd_backend, rel->rd_rel->relpersistence);
+	dstrel = smgropen_rp(newrlocator, rel->rd_backend, rel->rd_rel->relpersistence);
 
 	/*
 	 * Since we copy the file directly without looking at the shared buffers,

--- a/src/backend/storage/buffer/localbuf.c
+++ b/src/backend/storage/buffer/localbuf.c
@@ -248,10 +248,7 @@ GetLocalVictimBuffer(void)
 		Page		localpage = (char *) LocalBufHdrGetBlock(bufHdr);
 
 		/* Find smgr relation for buffer */
-		if (am_wal_redo_postgres && MyBackendId == InvalidBackendId)
-			oreln = smgropen(BufTagGetRelFileLocator(&bufHdr->tag), MyBackendId, RELPERSISTENCE_PERMANENT);
-		else
-			oreln = smgropen(BufTagGetRelFileLocator(&bufHdr->tag), MyBackendId, RELPERSISTENCE_TEMP);
+		oreln = smgropen(BufTagGetRelFileLocator(&bufHdr->tag), MyBackendId);
 
 		PageSetChecksumInplace(localpage, bufHdr->tag.blockNum);
 

--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -1257,7 +1257,7 @@ DropRelationFiles(RelFileLocator *delrels, int ndelrels, bool isRedo)
 	srels = palloc(sizeof(SMgrRelation) * ndelrels);
 	for (i = 0; i < ndelrels; i++)
 	{
-		SMgrRelation srel = smgropen(delrels[i], InvalidBackendId, 0);
+		SMgrRelation srel = smgropen_rp(delrels[i], InvalidBackendId, 0);
 
 		if (isRedo)
 		{
@@ -1541,7 +1541,7 @@ _mdnblocks(SMgrRelation reln, ForkNumber forknum, MdfdVec *seg)
 int
 mdsyncfiletag(const FileTag *ftag, char *path)
 {
-	SMgrRelation reln = smgropen(ftag->rlocator, InvalidBackendId, 0);
+	SMgrRelation reln = smgropen_rp(ftag->rlocator, InvalidBackendId, 0);
 	File		file;
 	instr_time	io_start;
 	bool		need_to_close;

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "access/xlogutils.h"
+#include "catalog/pg_class.h"
 #include "catalog/pg_tablespace.h"
 #include "lib/ilist.h"
 #include "storage/bufmgr.h"
@@ -127,6 +128,12 @@ smgr(BackendId backend, RelFileLocator rlocator)
 	return result;
 }
 
+SMgrRelation
+smgropen(RelFileLocator rlocator, BackendId backend)
+{
+	return smgropen_rp(rlocator, backend, backend == InvalidBackendId ? RELPERSISTENCE_PERMANENT : RELPERSISTENCE_TEMP);
+}
+
 /*
  * smgropen() -- Return an SMgrRelation object, creating it if need be.
  *
@@ -138,7 +145,7 @@ smgr(BackendId backend, RelFileLocator rlocator)
  * require it.
  */
 SMgrRelation
-smgropen(RelFileLocator rlocator, BackendId backend, char relpersistence)
+smgropen_rp(RelFileLocator rlocator, BackendId backend, char relpersistence)
 {
 	RelFileLocatorBackend brlocator;
 	SMgrRelation reln;

--- a/src/backend/utils/adt/dbsize.c
+++ b/src/backend/utils/adt/dbsize.c
@@ -319,7 +319,7 @@ static int64
 calculate_relation_size(RelFileLocator *rfn, BackendId backend,
 						ForkNumber forknum, char relpersistence)
 {
-	SMgrRelation srel = smgropen(*rfn, backend, relpersistence);
+	SMgrRelation srel = smgropen_rp(*rfn, backend, relpersistence);
 
 	if (smgrexists(srel, forknum))
 	{

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3783,7 +3783,7 @@ RelationSetNewRelfilenumber(Relation relation, char persistence)
 		 * fails at this stage, the new cluster will need to be recreated
 		 * anyway.
 		 */
-		srel = smgropen(relation->rd_locator, relation->rd_backend, persistence);
+		srel = smgropen_rp(relation->rd_locator, relation->rd_backend, persistence);
 		smgrdounlinkall(&srel, 1, false);
 		smgrclose(srel);
 	}

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -152,7 +152,8 @@ extern const f_smgr *smgr_standard(BackendId backend, RelFileLocator rlocator);
 extern const f_smgr *smgr(BackendId backend, RelFileLocator rlocator);
 
 extern void smgrinit(void);
-extern SMgrRelation smgropen(RelFileLocator rlocator, BackendId backend, char relpersistence);
+extern SMgrRelation smgropen_rp(RelFileLocator rlocator, BackendId backend, char relpersistence);
+extern SMgrRelation smgropen(RelFileLocator rlocator, BackendId backend);
 extern bool smgrexists(SMgrRelation reln, ForkNumber forknum);
 extern void smgrsetowner(SMgrRelation *owner, SMgrRelation reln);
 extern void smgrclearowner(SMgrRelation *owner, SMgrRelation reln);

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -572,7 +572,7 @@ static inline SMgrRelation
 RelationGetSmgr(Relation rel)
 {
 	if (unlikely(rel->rd_smgr == NULL))
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_locator, rel->rd_backend, rel->rd_rel->relpersistence));
+		smgrsetowner(&(rel->rd_smgr), smgropen_rp(rel->rd_locator, rel->rd_backend, rel->rd_rel->relpersistence));
 	return rel->rd_smgr;
 }
 


### PR DESCRIPTION
Adding extra parameter to smgropen in Neon broke compatibility with external extensions.

See https://neondb.slack.com/archives/C03QLRH7PPD/p1706945170255549
