### PR TITLE
fix compilation error in pg16 with ext patch

### DIFF
--- a/src/backend/commands/publicationcmds.c
+++ b/src/backend/commands/publicationcmds.c
@@ -728,13 +728,6 @@ CheckPubRelationColumnList(char *pubname, List *tables,
 	}
 }
 
-static bool
-is_neon_superuser(void)
-{
-	Oid neon_superuser_oid = get_role_oid("neon_superuser", true /*missing_ok*/);
-	return neon_superuser_oid != InvalidOid && has_privs_of_role(GetUserId(), neon_superuser_oid);
-}
-
 /*
  * Create new publication.
  */

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -123,6 +123,18 @@ static AclResult pg_role_aclcheck(Oid role_oid, Oid roleid, AclMode mode);
 
 static void RoleMembershipCacheCallback(Datum arg, int cacheid, uint32 hashvalue);
 
+bool
+is_neon_superuser(void)
+{
+	return is_neon_superuser_arg(GetUserId());
+}
+
+bool
+is_neon_superuser_arg(Oid roleid)
+{
+	Oid neon_superuser_oid = get_role_oid("neon_superuser", true /*missing_ok*/);
+	return neon_superuser_oid != InvalidOid && has_privs_of_role(roleid, neon_superuser_oid);
+}
 
 /*
  * getid

--- a/src/include/miscadmin.h
+++ b/src/include/miscadmin.h
@@ -381,6 +381,9 @@ extern const char *GetSystemUser(void);
 extern bool superuser(void);	/* current user is superuser */
 extern bool superuser_arg(Oid roleid);	/* given user is superuser */
 
+/* in utils/adt/acl.c */
+extern bool is_neon_superuser(void); /* current user is neon_superuser */
+extern bool is_neon_superuser_arg(Oid roleid); /* given user is neon_superuser */
 
 /*****************************************************************************
  *	  pmod.h --																 *


### PR DESCRIPTION
the previous patch didn't compile 🤣

@save-buffer i also noticed that `is_neon_superuser` is used in pg14/pg15 `subscriptioncmds.c` but not in pg16. Is it expected that pg16 uses different superuser check mechanism?