### PR TITLE
Set wasShutdown=true during hot-standby replica startup only when primary is not alive

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7244,6 +7244,7 @@ StartupXLOG(void)
 			 * FirstNormalTransactionId is conservative estimation of oldest active XACT, unless
 			 * current XID is greater than 1^31. So it is also not 100% safe solution but better than assertion failure.
 			 */
+			elog(FATAL, "oldestActiveXid=%d", checkPoint.oldestActiveXid);
 			checkPoint.oldestActiveXid = FirstNormalTransactionId;
 		}
 	}

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7043,15 +7043,25 @@ StartupXLOG(void)
 		EndRecPtr = ControlFile->checkPointCopy.redo;
 
 		memcpy(&checkPoint, &ControlFile->checkPointCopy, sizeof(CheckPoint));
-		// When normal (primary) Neon compute node is started, we assume that is started after normal shutdown and
-		// no recovery is needed.
-		// When read-only replica is started, we need to obtain information about running xacts, so wasShutdown is set to false.
-		// When snapshot read-only node is started, we can treat all active transactions as aborted so once again
-		// assume that we restart after normal shutdown.
-		wasShutdown = StandbyModeRequested
-			&& PrimaryConnInfo != NULL && *PrimaryConnInfo != '\0'
-			&& IsPrimaryAlive()
-			? false : true;
+		// When primary Neon compute node is started, we pretend that it started after a clean shutdown and
+		// no recovery is needed. We don't need to do WAL replay, the page server does that on a page-by-page basis.
+		// When a read-only replica is started, PostgreSQL normally waits for a shutdown checkpoint or running-xacts
+		// record before enabling hot standby, to establish which transactions are still running in the primary,
+		// and might still commit later. But if we know that the primary is not running - because the control plane
+		// says so - we can skip that. That avoids having to wait indefinitely if the primary is not running. This is
+		// particularly important for Neon because we don't start recovery from a checkpoint record, so there's
+		// no guarantee on when we'll see the next checkpoint or running-xacts record, if ever. so if we know the primary is
+		// not currently running, also set wasShutdown to 'true'.
+		if (StandbyModeRequested &&
+			PrimaryConnInfo != NULL && *PrimaryConnInfo != '\0')
+		{
+			if (!IsPrimaryAlive())
+				wasShutdown = true;
+			else
+				wasShutdown = false;
+		}
+		else
+			wasShutdown = true;
 
 		/* Initialize expectedTLEs, like ReadRecord() does */
 		expectedTLEs = readTimeLineHistory(checkPoint.ThisTimeLineID);

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7234,7 +7234,7 @@ StartupXLOG(void)
 	if (ZenithRecoveryRequested)
 	{
 		if (wasShutdown)
-			checkPoint.oldestActiveXid = 0;
+			checkPoint.oldestActiveXid = InvalidTransactionId;
 		else if (!TransactionIdIsValid(checkPoint.oldestActiveXid))
 			checkPoint.oldestActiveXid = FirstNormalTransactionId;
 	}

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -7236,7 +7236,16 @@ StartupXLOG(void)
 		if (wasShutdown)
 			checkPoint.oldestActiveXid = InvalidTransactionId;
 		else if (!TransactionIdIsValid(checkPoint.oldestActiveXid))
+		{
+			/*
+			 * It should not actually happen: PS oldestActiveXid
+			 * from running xacts WAL records and include it in checkpoint
+			 * sent in basebackup.
+			 * FirstNormalTransactionId is conservative estimation of oldest active XACT, unless
+			 * current XID is greater than 1^31. So it is also not 100% safe solution but better than assertion failure.
+			 */
 			checkPoint.oldestActiveXid = FirstNormalTransactionId;
+		}
 	}
 
 	/* initialize shared memory variables from the checkpoint record */


### PR DESCRIPTION
Postgres part of https://github.com/neondatabase/neon/pull/6705