### PR TITLE
cherry-pick: Fix 'mmap' DSM implementation with allocations larger than 4 GB

### DIFF
--- a/src/backend/storage/ipc/dsm_impl.c
+++ b/src/backend/storage/ipc/dsm_impl.c
@@ -880,7 +880,7 @@ dsm_impl_mmap(dsm_op op, dsm_handle handle, Size request_size,
 		 * transferring data to the kernel.
 		 */
 		char	   *zbuffer = (char *) palloc0(ZBUFFER_SIZE);
-		uint32		remaining = request_size;
+		Size		remaining = request_size;
 		bool		success = true;
 
 		/*


### PR DESCRIPTION
--- original commit message from Heikki ---

Fixes bug #18341. Backpatch to all supported versions.

Discussion: https://www.postgresql.org/message-id/18341-ce16599e7fd6228c@postgresql.org