### PR TITLE
Treat walproposer like walsenders in postmaster.

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -4115,7 +4115,8 @@ SignalSomeChildren(int signal, int target)
 			 * Assign bkend_type for any recently announced WAL Sender
 			 * processes.
 			 */
-			if (bp->bkend_type == BACKEND_TYPE_NORMAL &&
+			/* Neon: Also allow walproposer background worker to be treated like a WAL sender, so that it's shut down last */
+			if ((bp->bkend_type == BACKEND_TYPE_NORMAL || BACKEND_TYPE_BGWORKER) &&
 				IsPostmasterChildWalSender(bp->child_slot))
 				bp->bkend_type = BACKEND_TYPE_WALSND;
 
@@ -5370,7 +5371,8 @@ CountChildren(int target)
 			 * Assign bkend_type for any recently announced WAL Sender
 			 * processes.
 			 */
-			if (bp->bkend_type == BACKEND_TYPE_NORMAL &&
+			/* Neon: Also allow walproposer background worker to be treated like a WAL sender, so that it's shut down last */
+			if ((bp->bkend_type == BACKEND_TYPE_NORMAL || BACKEND_TYPE_BGWORKER) &&
 				IsPostmasterChildWalSender(bp->child_slot))
 				bp->bkend_type = BACKEND_TYPE_WALSND;
 


### PR DESCRIPTION
This keeps the walproposer processes alive at shutdown, until after the shutdown checkpoint has been written. That gives the walproposers a chance to stream it to the safekeepers.