### PR TITLE
Flush logical messages with snapshots and replication origin

### DIFF
--- a/src/backend/replication/logical/origin.c
+++ b/src/backend/replication/logical/origin.c
@@ -676,7 +676,7 @@ CheckPointReplicationOrigin(void)
 		chkp_size += sizeof(crc);
 
 		/* NEON specific: persist snapshot in storage using logical message */
-		LogLogicalMessage("neon-file:pg_logical/replorigin_checkpoint", buf, chkp_size, false);
+		XLogFlush(LogLogicalMessage("neon-file:pg_logical/replorigin_checkpoint", buf, chkp_size, false));
 	}
 	pfree(buf);
 

--- a/src/backend/replication/logical/snapbuild.c
+++ b/src/backend/replication/logical/snapbuild.c
@@ -1737,7 +1737,7 @@ SnapBuildSerialize(SnapBuild *builder, XLogRecPtr lsn)
 
 	/* NEON specific: persist snapshot in storage using logical message */
 	snprintf(prefix, sizeof(prefix), "neon-file:%s", path);
-	LogLogicalMessage(prefix, (char*)ondisk, needed_length, false);
+	XLogFlush(LogLogicalMessage(prefix, (char*)ondisk, needed_length, false));
 
 	errno = 0;
 	pgstat_report_wait_start(WAIT_EVENT_SNAPBUILD_WRITE);
@@ -2106,7 +2106,7 @@ CheckPointSnapBuild(void)
 
 			/* NEON specific: delete file from storage using logical message */
 			snprintf(prefix, sizeof(prefix), "neon-file:%s", path);
-			LogLogicalMessage(prefix, NULL, 0, false);
+			XLogFlush(LogLogicalMessage(prefix, NULL, 0, false));
 
 			/*
 			 * It's not particularly harmful, though strange, if we can't


### PR DESCRIPTION
See https://neondb.slack.com/archives/C04DGM6SMTM/p1708363190710839