### PR TITLE
Show information about local file cache in EXPLAIN ANALYZE

### DIFF
--- a/src/backend/executor/instrument.c
+++ b/src/backend/executor/instrument.c
@@ -239,6 +239,8 @@ BufferUsageAdd(BufferUsage *dst, const BufferUsage *add)
 	dst->prefetch.misses += add->prefetch.misses;
 	dst->prefetch.expired += add->prefetch.expired;
 	dst->prefetch.duplicates += add->prefetch.duplicates;
+	dst->file_cache.hits += add->file_cache.hits;
+	dst->file_cache.misses += add->file_cache.misses;
 	INSTR_TIME_ADD(dst->blk_read_time, add->blk_read_time);
 	INSTR_TIME_ADD(dst->blk_write_time, add->blk_write_time);
 	INSTR_TIME_ADD(dst->temp_blk_read_time, add->temp_blk_read_time);
@@ -265,6 +267,8 @@ BufferUsageAccumDiff(BufferUsage *dst,
 	dst->prefetch.misses += add->prefetch.misses - sub->prefetch.misses;
 	dst->prefetch.expired += add->prefetch.expired - sub->prefetch.expired;
 	dst->prefetch.duplicates += add->prefetch.duplicates - sub->prefetch.duplicates;
+	dst->file_cache.hits += add->file_cache.hits - sub->file_cache.hits;
+	dst->file_cache.misses += add->file_cache.misses - sub->file_cache.misses;
 	INSTR_TIME_ACCUM_DIFF(dst->blk_read_time,
 						  add->blk_read_time, sub->blk_read_time);
 	INSTR_TIME_ACCUM_DIFF(dst->blk_write_time,

--- a/src/include/commands/explain.h
+++ b/src/include/commands/explain.h
@@ -47,6 +47,7 @@ typedef struct ExplainState
 	bool		summary;		/* print total planning and execution timing */
 	bool		settings;		/* print modified settings */
 	bool		prefetch;		/* print prefetch statistic */
+	bool		file_cache;		/* print file cache statistic */
 	ExplainFormat format;		/* output format */
 	/* state for output formatting --- not reset for each new plan tree */
 	int			indent;			/* current indentation level */

--- a/src/include/executor/instrument.h
+++ b/src/include/executor/instrument.h
@@ -24,6 +24,13 @@ typedef struct
 	int64 duplicates;
 } PrefetchInfo;
 
+/* Local file cache statistics */
+typedef struct
+{
+	int64 hits;
+	int64 misses;
+} FileCacheInfo;
+
 /*
  * BufferUsage and WalUsage counters keep being incremented infinitely,
  * i.e., must never be reset to zero, so that we can calculate how much
@@ -45,7 +52,8 @@ typedef struct BufferUsage
 	instr_time	blk_write_time; /* time spent writing blocks */
 	instr_time	temp_blk_read_time; /* time spent reading temp blocks */
 	instr_time	temp_blk_write_time;	/* time spent writing temp blocks */
-	PrefetchInfo prefetch; /* prefetch statistics */ 
+	PrefetchInfo prefetch; /* prefetch statistics */
+	FileCacheInfo file_cache; /* local file cache statistics */
 } BufferUsage;
 
 /*


### PR DESCRIPTION
```
explain (analyze,buffers,prefetch,filecache) select count(*) from pgbench_accounts;
                                                                                         QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=214486.94..214486.95 rows=1 width=8) (actual time=5195.378..5196.034 rows=1 loops=1)
   Buffers: shared hit=178875 read=143691 dirtied=128597 written=127346
   Prefetch: hits=0 misses=1865 expired=0 duplicates=0
   File cache: hits=141826 misses=1865
   ->  Gather  (cost=214486.73..214486.94 rows=2 width=8) (actual time=5195.366..5196.025 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         Buffers: shared hit=178875 read=143691 dirtied=128597 written=127346
         Prefetch: hits=0 misses=1865 expired=0 duplicates=0
         File cache: hits=141826 misses=1865
         ->  Partial Aggregate  (cost=213486.73..213486.74 rows=1 width=8) (actual time=5187.670..5187.670 rows=1 loops=3)
               Buffers: shared hit=178875 read=143691 dirtied=128597 written=127346
               Prefetch: hits=0 misses=1865 expired=0 duplicates=0
               File cache: hits=141826 misses=1865
               ->  Parallel Index Only Scan using pgbench_accounts_pkey on pgbench_accounts  (cost=0.43..203003.02 rows=4193481 width=0) (actual time=0.574..4928.995 rows=3333333 loops=3)
                     Heap Fetches: 3675286
                     Buffers: shared hit=178875 read=143691 dirtied=128597 written=127346
                     Prefetch: hits=0 misses=1865 expired=0 duplicates=0
                     File cache: hits=141826 misses=1865
```