### PR TITLE
Print backtrace of the attempt to set GUC in parallel content

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -3366,7 +3366,8 @@ set_config_option_ext(const char *name, const char *value,
 	{
 		ereport(elevel,
 				(errcode(ERRCODE_INVALID_TRANSACTION_STATE),
-				 errmsg("cannot set parameters during a parallel operation")));
+				 errmsg("cannot set parameters during a parallel operation"),
+				 errbacktrace()));
 		return -1;
 	}
 

--- a/src/backend/utils/misc/guc_funcs.c
+++ b/src/backend/utils/misc/guc_funcs.c
@@ -51,7 +51,8 @@ ExecSetVariableStmt(VariableSetStmt *stmt, bool isTopLevel)
 	if (IsInParallelMode())
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TRANSACTION_STATE),
-				 errmsg("cannot set parameters during a parallel operation")));
+				 errmsg("cannot set parameters during a parallel operation"),
+				 errbacktrace()));
 
 	switch (stmt->kind)
 	{


### PR DESCRIPTION
See https://neondb.slack.com/archives/C03QLRH7PPD/p1709312705953569