### PR TITLE
Remember last written LSN when it is first requested

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6281,6 +6281,12 @@ GetLastWrittenLSN(RelFileLocator rlocator, ForkNumber forknum, BlockNumber blkno
 		entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
 		if (entry != NULL)
 			lsn = entry->lsn;
+		else
+		{
+			LWLockRelease(LastWrittenLsnLock);
+			SetLastWrittenLSNForBlock(lsn, rlocator, forknum, blkno);
+			return lsn;
+		}
 	}
 	else
 	{

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -261,10 +261,10 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 
 /* neon specifics */
 
-extern void SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
-extern void SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
-extern void SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
-extern void SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
+extern XLogRecPtr SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
+extern XLogRecPtr SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
+extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
+extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileLocator relfilenode, ForkNumber forknum);
 extern XLogRecPtr GetLastWrittenLSN(RelFileLocator relfilenode, ForkNumber forknum, BlockNumber blkno);
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);


### PR DESCRIPTION
See https://neondb.slack.com/archives/C03QLRH7PPD/p1712529369520409

In case of statements `CREATE TABLE AS SELECT...` or `INSERT FROM SELECT...` we are fetching data from source table and storing it in destination table. It cause problems with prefetch last-written-lsn is known for the pages of source table
(which for example happens after compute restart). In this case we get get global value of last-written-lsn which is changed frequently as far as we are writing pages of destination table. As a result request-isn for the prefetch and request-let when this page is actually needed are different and we got exported prefetch request. So it actually disarms prefetch.

Proposed simple patch stores last-written LSN for the page when it is not found. So next time we will request last-written LSN for this page, we will get the same value (certainly if the page was not changed).