### PR TITLE
Remember last written LSN when it is first requested

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6235,7 +6235,6 @@ SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum,
 /*
  * SetLastWrittenLSNForRelation -- Set maximal LSN for relation metadata
  */
-
 XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum)
 {

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6133,6 +6133,12 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 		entry = hash_search(lastWrittenLsnCache, &key, HASH_FIND, NULL);
 		if (entry != NULL)
 			lsn = entry->lsn;
+		else
+		{
+			LWLockRelease(LastWrittenLsnLock);
+			SetLastWrittenLSNForBlock(lsn, rlocator, forknum, blkno);
+			return lsn;
+		}
 	}
 	else
 	{

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6136,7 +6136,7 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 		else
 		{
 			LWLockRelease(LastWrittenLsnLock);
-			SetLastWrittenLSNForBlock(lsn, rlocator, forknum, blkno);
+			SetLastWrittenLSNForBlock(lsn, rnode, forknum, blkno);
 			return lsn;
 		}
 	}

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -6136,8 +6136,7 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 		else
 		{
 			LWLockRelease(LastWrittenLsnLock);
-			SetLastWrittenLSNForBlock(lsn, rnode, forknum, blkno);
-			return lsn;
+			return SetLastWrittenLSNForBlock(lsn, rnode, forknum, blkno);
 		}
 	}
 	else
@@ -6166,17 +6165,19 @@ GetLastWrittenLSN(RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
  * rnode.relNode can be InvalidOid, in this case maxLastWrittenLsn is updated.
  * SetLastWrittenLsn with dummy rnode is used by createdb and dbase_redo functions.
  */
-void
+XLogRecPtr
 SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks)
 {
 	if (lsn == InvalidXLogRecPtr || n_blocks == 0 || lastWrittenLsnCacheSize == 0)
-		return;
+		return lsn;
 
 	LWLockAcquire(LastWrittenLsnLock, LW_EXCLUSIVE);
 	if (rnode.relNode == InvalidOid)
 	{
 		if (lsn > XLogCtl->maxLastWrittenLsn)
 			XLogCtl->maxLastWrittenLsn = lsn;
+		else
+			lsn = XLogCtl->maxLastWrittenLsn;
 	}
 	else
 	{
@@ -6195,6 +6196,8 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber for
 			{
 				if (lsn > entry->lsn)
 					entry->lsn = lsn;
+				else
+					lsn = entry->lsn;
 				/* Unlink from LRU list */
 				dlist_delete(&entry->lru_node);
 			}
@@ -6217,34 +6220,36 @@ SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode rnode, ForkNumber for
 		}
 	}
 	LWLockRelease(LastWrittenLsnLock);
+	return lsn;
 }
 
 /*
  * SetLastWrittenLSNForBlock -- Set maximal LSN for block
  */
-void
+XLogRecPtr
 SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum, BlockNumber blkno)
 {
-	SetLastWrittenLSNForBlockRange(lsn, rnode, forknum, blkno, 1);
+	return SetLastWrittenLSNForBlockRange(lsn, rnode, forknum, blkno, 1);
 }
 
 /*
  * SetLastWrittenLSNForRelation -- Set maximal LSN for relation metadata
  */
-void
+
+XLogRecPtr
 SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode rnode, ForkNumber forknum)
 {
-	SetLastWrittenLSNForBlock(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
+	return SetLastWrittenLSNForBlock(lsn, rnode, forknum, REL_METADATA_PSEUDO_BLOCKNO);
 }
 
 /*
  * SetLastWrittenLSNForDatabase -- Set maximal LSN for the whole database
  */
-void
+XLogRecPtr
 SetLastWrittenLSNForDatabase(XLogRecPtr lsn)
 {
 	RelFileNode dummyNode = {InvalidOid, InvalidOid, InvalidOid};
-	SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
+	return SetLastWrittenLSNForBlock(lsn, dummyNode, MAIN_FORKNUM, 0);
 }
 
 void

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -256,10 +256,10 @@ extern XLogRecPtr GetLastImportantRecPtr(void);
 
 /* neon specifics */
 
-extern void SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
-extern void SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
-extern void SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
-extern void SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
+extern XLogRecPtr SetLastWrittenLSNForBlock(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
+extern XLogRecPtr SetLastWrittenLSNForBlockRange(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum, BlockNumber from, BlockNumber n_blocks);
+extern XLogRecPtr SetLastWrittenLSNForDatabase(XLogRecPtr lsn);
+extern XLogRecPtr SetLastWrittenLSNForRelation(XLogRecPtr lsn, RelFileNode relfilenode, ForkNumber forknum);
 extern XLogRecPtr GetLastWrittenLSN(RelFileNode relfilenode, ForkNumber forknum, BlockNumber blkno);
 
 extern void SetRedoStartLsn(XLogRecPtr RedoStartLSN);


### PR DESCRIPTION
See https://neondb.slack.com/archives/C03QLRH7PPD/p1712529369520409

In case of statements CREATE TABLE AS SELECT... or INSERT FROM SELECT... we are fetching data from source table and storing it in destination table. It cause problems with prefetch last-written-lsn is known for the pages of source table
(which for example happens after compute restart). In this case we get get global value of last-written-lsn which is changed frequently as far as we are writing pages of destination table. As a result request-isn for the prefetch and request-let when this page is actually needed are different and we got exported prefetch request. So it actually disarms prefetch.

Proposed simple patch stores last-written LSN for the page when it is not found. So next time we will request last-written LSN for this page, we will get the same value (certainly if the page was not changed).