### PR TITLE
Don't set wasShutdown=true when starting a read replica (v16)

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -804,7 +804,30 @@ InitWalRecovery(ControlFileData *ControlFile, bool *wasShutdown_ptr,
 		//EndRecPtr = ControlFile->checkPointCopy.redo;
 
 		memcpy(&checkPoint, &ControlFile->checkPointCopy, sizeof(CheckPoint));
-		wasShutdown = true;
+
+		/*
+		 * When a primary Neon compute node is started, we pretend that it
+		 * started after a clean shutdown and no recovery is needed. We don't
+		 * need to do WAL replay to make the database consistent, the page
+		 * server does that on a page-by-page basis.
+		 *
+		 * When starting a read-only replica, we will also start from a
+		 * consistent snapshot of the cluster the start LSN, so we don't need
+		 * to perform WAL replay to get there. However, wasShutdown must be
+		 * set to false, because wasShutdown==true would imply that there are
+		 * no transactions still in-progress at the start LSN, and we would
+		 * initialize the known-assigned XIDs machinery for hot standby
+		 * incorrectly. If this is a static read-only node that doesn't follow
+		 * the primary though, then it's OK, as we will never see the possible
+		 * commits of the in-progress transactions.
+		 */
+		if (StandbyModeRequested &&
+			PrimaryConnInfo != NULL && *PrimaryConnInfo != '\0')
+		{
+			wasShutdown = false;
+		}
+		else
+			wasShutdown = true;
 
 		/* Initialize expectedTLEs, like ReadRecord() does */
 		expectedTLEs = readTimeLineHistory(checkPoint.ThisTimeLineID);

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -13,6 +13,7 @@
 
 #include "access/xlogbackup.h"
 #include "access/xlogdefs.h"
+#include "catalog/pg_control.h"
 #include "datatype/timestamp.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
@@ -310,6 +311,10 @@ extern void do_pg_backup_stop(BackupState *state, bool waitforarchive);
 extern void do_pg_abort_backup(int code, Datum arg);
 extern void register_persistent_abort_backup_handler(void);
 extern SessionBackupState get_backup_status(void);
+
+/* NEON: Hook to allow the neon extension to restore running-xacts from CLOG at replica startup */
+typedef bool (*restore_running_xacts_callback_t) (CheckPoint *checkpoint, TransactionId **xids, int *nxids);
+extern restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* File path names (all relative to $PGDATA) */
 #define RECOVERY_SIGNAL_FILE	"recovery.signal"


### PR DESCRIPTION
That led to incorrect query results, because the known-assigned XIDs machinery was initialized incorrectly thinking that all of the in-progress transactions were aborted.

Introduce a new hook, to allow the neon extension to restore running-xacts from the CLOG.