### PR TITLE
Don't set wasShutdown=true when starting a read replica (v15)

### DIFF
--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -146,6 +146,9 @@ bool		XLOG_DEBUG = false;
 
 int			wal_segment_size = DEFAULT_XLOG_SEG_SIZE;
 
+/* NEON: Hook to allow the neon extension to restore running-xacts from CLOG at replica startup */
+restore_running_xacts_callback_t restore_running_xacts_callback;
+
 /*
  * Number of WAL insertion locks to use. A higher value allows more insertions
  * to happen concurrently, but adds some CPU overhead to flushing the WAL,
@@ -5403,8 +5406,9 @@ StartupXLOG(void)
 		 */
 		if (ArchiveRecoveryRequested && EnableHotStandby)
 		{
-			TransactionId *xids;
+			TransactionId *xids = NULL;
 			int			nxids;
+			bool		apply_running_xacts = false;
 
 			ereport(DEBUG1,
 					(errmsg_internal("initializing for hot standby")));
@@ -5432,14 +5436,33 @@ StartupXLOG(void)
 			 * nothing was running on the primary at this point. So fake-up an
 			 * empty running-xacts record and use that here and now. Recover
 			 * additional standby state for prepared transactions.
+			 *
+			 * Neon: We also use a similar mechanism to start up sooner at
+			 * replica startup, by scanning the CLOG and faking a running-xacts
+			 * record based on that.
 			 */
 			if (wasShutdown)
+			{
+				/* Update pg_subtrans entries for any prepared transactions */
+				StandbyRecoverPreparedTransactions();
+				apply_running_xacts = true;
+			}
+			else if (restore_running_xacts_callback)
+			{
+				/*
+				 * Update pg_subtrans entries for any prepared transactions before
+				 * calling the extension hook.
+				 */
+				StandbyRecoverPreparedTransactions();
+				apply_running_xacts = restore_running_xacts_callback(&checkPoint, &xids, &nxids);
+			}
+
+			if (apply_running_xacts)
 			{
 				RunningTransactionsData running;
 				TransactionId latestCompletedXid;
 
-				/* Update pg_subtrans entries for any prepared transactions */
-				StandbyRecoverPreparedTransactions();
+				/* Neon: called StandbyRecoverPreparedTransactions() above already */
 
 				/*
 				 * Construct a RunningTransactions snapshot representing a

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -13,6 +13,7 @@
 
 #include "access/xlogdefs.h"
 #include "access/xlogreader.h"
+#include "catalog/pg_control.h"
 #include "datatype/timestamp.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
@@ -309,6 +310,10 @@ extern XLogRecPtr do_pg_backup_stop(char *labelfile, bool waitforarchive,
 extern void do_pg_abort_backup(int code, Datum arg);
 extern void register_persistent_abort_backup_handler(void);
 extern SessionBackupState get_backup_status(void);
+
+/* NEON: Hook to allow the neon extension to restore running-xacts from CLOG at replica startup */
+typedef bool (*restore_running_xacts_callback_t) (CheckPoint *checkpoint, TransactionId **xids, int *nxids);
+extern restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* File path names (all relative to $PGDATA) */
 #define RECOVERY_SIGNAL_FILE	"recovery.signal"


### PR DESCRIPTION
That led to incorrect query results, because the known-assigned XIDs machinery was initialized incorrectly thinking that all of the in-progress transactions were aborted.

Introduce a new hook, to allow the neon extension to restore running-xacts from the CLOG.