### PR TITLE
Don't set wasShutdown=true when starting a read replica (v14)

### DIFF
--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -15,6 +15,7 @@
 #include "access/xlogdefs.h"
 #include "access/xloginsert.h"
 #include "access/xlogreader.h"
+#include "catalog/pg_control.h"
 #include "datatype/timestamp.h"
 #include "lib/stringinfo.h"
 #include "nodes/pg_list.h"
@@ -408,6 +409,10 @@ extern XLogRecPtr do_pg_stop_backup(char *labelfile, bool waitforarchive,
 extern void do_pg_abort_backup(int code, Datum arg);
 extern void register_persistent_abort_backup_handler(void);
 extern SessionBackupState get_backup_status(void);
+
+/* NEON: Hook to allow the neon extension to restore running-xacts from CLOG at replica startup */
+typedef bool (*restore_running_xacts_callback_t) (CheckPoint *checkpoint, TransactionId **xids, int *nxids);
+extern restore_running_xacts_callback_t restore_running_xacts_callback;
 
 /* File path names (all relative to $PGDATA) */
 #define RECOVERY_SIGNAL_FILE	"recovery.signal"


### PR DESCRIPTION
That led to incorrect query results, because the known-assigned XIDs machinery was initialized incorrectly thinking that all of the in-progress transactions were aborted.

Introduce a new hook, to allow the neon extension to restore running-xacts from the CLOG.