### PR TITLE
Make logical apply worker take into account syncrep flush position.

### DIFF
--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -183,6 +183,7 @@
 #include "replication/reorderbuffer.h"
 #include "replication/snapbuild.h"
 #include "replication/walreceiver.h"
+#include "replication/walsender_private.h"
 #include "replication/worker_internal.h"
 #include "rewrite/rewriteHandler.h"
 #include "storage/buffile.h"
@@ -3407,6 +3408,19 @@ get_flush_position(XLogRecPtr *write, XLogRecPtr *flush,
 {
 	dlist_mutable_iter iter;
 	XLogRecPtr	local_flush = GetFlushRecPtr(NULL);
+
+	/*
+	 * If synchronous replication is configured, take into account its position.
+	 * This is particularly important in neon where WAL is hardened only after
+	 * it is flushed on majority of safekeepers.
+	 */
+	if (SyncRepStandbyNames != NULL && SyncRepStandbyNames[0] != '\0')
+	{
+		/* assumes u64 read is atomic */
+		XLogRecPtr  sync_rep_flush = WalSndCtl->lsn[SYNC_REP_WAIT_FLUSH];
+
+		local_flush = Min(local_flush, sync_rep_flush);
+	}
 
 	*write = InvalidXLogRecPtr;
 	*flush = InvalidXLogRecPtr;


### PR DESCRIPTION
Without this, it may ack higher than it, losing data on endpoint restart.