### PR TITLE
Revert "Add on-demand WAL download in CreateReplicationSlot (#471)"

### DIFF
--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -967,7 +967,6 @@ CreateReplicationSlot(CreateReplicationSlotCmd *cmd)
 	{
 		LogicalDecodingContext *ctx;
 		bool		need_full_snapshot = false;
-		XLogReaderRoutine xlr;
 
 		/*
 		 * Do options check early so that we can bail before calling the
@@ -1012,15 +1011,11 @@ CreateReplicationSlot(CreateReplicationSlotCmd *cmd)
 			need_full_snapshot = true;
 		}
 
-		xlr.page_read = logical_read_xlog_page;
-		xlr.segment_open = WalSndSegmentOpen;
-		xlr.segment_close = wal_segment_close;
-		if (WalSender_Custom_XLogReaderRoutines != NULL)
-			WalSender_Custom_XLogReaderRoutines(&xlr);
-
 		ctx = CreateInitDecodingContext(cmd->plugin, NIL, need_full_snapshot,
 										InvalidXLogRecPtr,
-										&xlr,
+										XL_ROUTINE(.page_read = logical_read_xlog_page,
+												   .segment_open = WalSndSegmentOpen,
+												   .segment_close = wal_segment_close),
 										WalSndPrepareWrite, WalSndWriteData,
 										WalSndUpdateProgress);
 


### PR DESCRIPTION
This reverts commit d48d08d1c0130c7e5d61b10f02bcbae629082a57.

Reason:

This was accidentally only committed to the REL_14_STABLE_neon branch, even though we need the same change in all Postgres versions. And the submodule reference in the 'neon' repository was never updated, so we never actually shipped this change.

The merged PR was a few bricks shy of a load: there were more changes on the v16 PR than the v15 and v14 PRs. Also, there were no tests.

To get us back to a known good state, revert this now. Later, write tests, and open a new set of PRs for all the branches.