### PR TITLE
Use on-demand WAL download function in CreateInitDecodingContext

### DIFF
--- a/src/backend/replication/slotfuncs.c
+++ b/src/backend/replication/slotfuncs.c
@@ -127,6 +127,13 @@ create_logical_replication_slot(char *name, char *plugin,
 								bool find_startpoint)
 {
 	LogicalDecodingContext *ctx = NULL;
+	XLogReaderRoutine xlr;
+	xlr.page_read = read_local_xlog_page;
+	xlr.segment_open = wal_segment_open;
+	xlr.segment_close = wal_segment_close;
+
+	if (SlotFuncs_Custom_XLogReaderRoutines != NULL)
+		SlotFuncs_Custom_XLogReaderRoutines(&xlr);
 
 	Assert(!MyReplicationSlot);
 
@@ -152,9 +159,7 @@ create_logical_replication_slot(char *name, char *plugin,
 	ctx = CreateInitDecodingContext(plugin, NIL,
 									false,	/* just catalogs is OK */
 									restart_lsn,
-									XL_ROUTINE(.page_read = read_local_xlog_page,
-											   .segment_open = wal_segment_open,
-											   .segment_close = wal_segment_close),
+									&xlr,
 									NULL, NULL, NULL);
 
 	/*


### PR DESCRIPTION
See https://github.com/neondatabase/neon/issues/8931