### PR TITLE
ERROR out instead of segfaulting when walsender slots are full.As comment says, this shouldn't happen in vanilla, but may be possiblein neon because of walproposer. v14

### DIFF
--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -2502,7 +2502,16 @@ InitWalSenderSlot(void)
 		}
 	}
 
-	Assert(MyWalSnd != NULL);
+	/*
+	 * neon: in vanilla this doesn't happen because walsenders register in
+	 * InitProcess walsenderFreeProcs which is also limited by max_wal_senders.
+	 * However, in neon walproposer occupies walsender slot but doesn't register
+	 * in walsenderFreeProcs (it's a bgworker).
+	 */
+	if (!MyWalSnd)
+	{
+		elog(ERROR, "out of walsender slots, consider increasing max_wal_senders");
+	}
 
 	/* Arrange to clean up at walsender exit */
 	on_shmem_exit(WalSndKill, 0);


### PR DESCRIPTION
As comment says, this shouldn't happen in vanilla, but may be possible
in neon because of walproposer.
