### PR TITLE
logical worker: respond to publisher even under dense stream. v15

### DIFF
--- a/src/backend/replication/logical/worker.c
+++ b/src/backend/replication/logical/worker.c
@@ -2745,6 +2745,9 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 
 		if (len != 0)
 		{
+			/* how many messages processed in a tight loop */
+			int n_processed = 0;
+
 			/* Loop to process all available data (without blocking). */
 			for (;;)
 			{
@@ -2796,9 +2799,26 @@ LogicalRepApplyLoop(XLogRecPtr last_received)
 						if (last_received < end_lsn)
 							last_received = end_lsn;
 
-						UpdateWorkerStats(last_received, send_time, false);
-
 						apply_dispatch(&s);
+
+						/*
+						 * Even under tight loop of data periodically send reply
+						 * to allow advancing the slot. Postgres walsender
+						 * normally sends 'k' if it hasn't seen replies for a
+						 * long time even if has more data to send, but we've
+						 * observed them missing when publiser was alloydb.
+						 */
+						n_processed++;
+						if (n_processed % 1000 == 0)
+						{
+							send_feedback(last_received, false, false);
+							UpdateWorkerStats(last_received, send_time, true);
+						}
+						else
+						{
+							UpdateWorkerStats(last_received, send_time, false);
+						}
+
 					}
 					else if (c == 'k')
 					{


### PR DESCRIPTION
Otherwise, if publisher doesn't send keepalive 'k' it won't be able to
advance the slot for a long time.
