### PR TITLE
Log the replication slot's confirmed_flush LSN when it is saved

### DIFF
--- a/src/backend/replication/slot.c
+++ b/src/backend/replication/slot.c
@@ -1837,7 +1837,11 @@ SaveSlotToPath(ReplicationSlot *slot, const char *dir, int elevel)
 		/* NEON specific: persist slot in storage using logical message */
 		char		prefix[MAXPGPATH];
 		snprintf(prefix, sizeof(prefix), "neon-file:%s", path);
-		elog(LOG, "Save replication slot at %s restart_lsn=%X/%X", path, 	LSN_FORMAT_ARGS(cp.slotdata.restart_lsn));
+		elog(LOG,
+			 "Save replication slot at %s restart_lsn=%X/%X confirmed_flush=%X/%X",
+			 path,
+			 LSN_FORMAT_ARGS(cp.slotdata.restart_lsn),
+			 LSN_FORMAT_ARGS(cp.slotdata.confirmed_flush));
 		XLogFlush(LogLogicalMessage(prefix, (char*)&cp, sizeof cp, false));
 	}
 


### PR DESCRIPTION
Useful when skimming logs to understand what data the consumer has already received.